### PR TITLE
Form Component

### DIFF
--- a/src/actions/field-actions.js
+++ b/src/actions/field-actions.js
@@ -1,8 +1,5 @@
 import _get from 'lodash/get';
-import mapValues from 'lodash/mapValues';
 import actionTypes from '../action-types';
-import actions from '../actions';
-import { getValue } from '../utils';
 
 const focus = model => ({
   type: actionTypes.FOCUS,

--- a/src/actions/field-actions.js
+++ b/src/actions/field-actions.js
@@ -1,5 +1,8 @@
 import _get from 'lodash/get';
+import mapValues from 'lodash/mapValues';
 import actionTypes from '../action-types';
+import actions from '../actions';
+import { getValue } from '../utils';
 
 const focus = model => ({
   type: actionTypes.FOCUS,
@@ -8,11 +11,6 @@ const focus = model => ({
 
 const blur = model => ({
   type: actionTypes.BLUR,
-  model,
-});
-
-const validate = model => ({
-  type: actionTypes.VALIDATE,
   model,
 });
 
@@ -115,5 +113,4 @@ export default {
   setUntouched,
   setValidity,
   setViewValue,
-  validate,
 };

--- a/src/components/field-component.js
+++ b/src/components/field-component.js
@@ -11,7 +11,7 @@ import partial from 'lodash/partial';
 
 import actions from '../actions';
 import Control from './control-component';
-import { isMulti, getValue } from '../utils';
+import { isMulti, getValue, validate } from '../utils';
 
 const { asyncSetValidity, blur, change, focus, setValidity, toggle, xor } = actions;
 
@@ -126,10 +126,7 @@ function sequenceEventActions(control, props) {
 
   if (props.validators) {
     const dispatchValidate = value => {
-      const validity = mapValues(
-        props.validators,
-        validator => validator(getValue(value))
-      );
+      const validity = validate(props.validators, value);
 
       dispatch(setValidity(model, validity));
 

--- a/src/components/form-component.js
+++ b/src/components/form-component.js
@@ -1,4 +1,4 @@
-/* eslint-disable */
+
 // TODO: Fix all eslint issues
 import React, { Component, PropTypes } from 'react';
 import connect from 'react-redux/lib/components/connect';
@@ -10,15 +10,47 @@ import actions from '../actions';
 import { validate, isValid } from '../utils';
 
 class Form extends Component {
+  constructor(props) {
+    super(props);
+
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+  componentDidUpdate(prevProps) {
+    /* eslint-disable react/prop-types */
+    const {
+      validators,
+      model,
+      dispatch,
+      validateOn,
+    } = this.props;
+    /* eslint-enable react/prop-types */
+
+    if (validateOn !== 'change') return;
+
+    mapValues(validators, (validator, field) => {
+      const fieldModel = [model, field].join('.');
+      const value = _get(this.props, fieldModel);
+
+      if (value === _get(prevProps, fieldModel)) return;
+
+      const validity = validate(validator, value);
+
+      dispatch(actions.setValidity(fieldModel, validity));
+    });
+  }
+
   handleSubmit(e) {
     e.preventDefault();
 
+    /* eslint-disable react/prop-types */
     const {
       model,
       validators,
       onSubmit,
-      dispatch
+      dispatch,
     } = this.props;
+    /* eslint-enable react/prop-types */
+
     const modelValue = _get(this.props, model);
 
     const valid = isValid(mapValues(validators, (validator, field) => {
@@ -36,47 +68,27 @@ class Form extends Component {
     }
   }
 
-  componentDidUpdate(prevProps) {
-    const {
-      validators,
-      model,
-      modelValue,
-      dispatch,
-      validateOn
-    } = this.props;
-
-    if (validateOn !== 'change') return;
-
-    mapValues(validators, (validator, field) => {
-      const fieldModel = [model, field].join('.');
-      const value = _get(this.props, fieldModel);
-
-      if (value === _get(prevProps, fieldModel)) return;
-
-      const validity = validate(validator, value);
-
-      dispatch(actions.setValidity(fieldModel, validate(validator, value)));
-    });
-  }
-
   render() {
+    /* eslint-disable react/prop-types */
     return (
       <form
         {...this.props}
-        onSubmit={(e) => this.handleSubmit(e)}
+        onSubmit={this.handleSubmit}
       >
         { this.props.children }
       </form>
     );
+    /* eslint-enable react/prop-types */
   }
 }
 
-Form.PropTypes = {
+Form.propTypes = {
   validators: PropTypes.object,
   validateOn: PropTypes.oneOf([
     'change',
   ]),
-  model: PropTypes.string.isRequired
+  model: PropTypes.string.isRequired,
+  onSubmit: PropTypes.func,
 };
 
 export default connect(identity)(Form);

--- a/src/components/form-component.js
+++ b/src/components/form-component.js
@@ -4,8 +4,10 @@ import React, { Component, PropTypes } from 'react';
 import connect from 'react-redux/lib/components/connect';
 import _get from 'lodash/get';
 import identity from 'lodash/identity';
+import mapValues from 'lodash/mapValues';
 
 import actions from '../actions';
+import { validate, isValid } from '../utils';
 
 class Form extends Component {
   handleSubmit(e) {
@@ -25,10 +27,11 @@ class Form extends Component {
       const validator = validators[field];
       const fieldModel = [model, field].join('.');
       const value = _get(this.props, fieldModel);
+      const validity = validate(validator, value);
 
-      valid = valid && validator(value);
+      valid = valid && isValid(validity);
 
-      dispatch(actions.setValidity(fieldModel, validator(value)));
+      dispatch(actions.setValidity(fieldModel, validate(validator, value)));
     });
 
     if (!valid) {

--- a/src/components/form-component.js
+++ b/src/components/form-component.js
@@ -11,6 +11,8 @@ import { validate, isValid } from '../utils';
 
 class Form extends Component {
   handleSubmit(e) {
+    e.preventDefault();
+
     const {
       model,
       validators,
@@ -19,19 +21,15 @@ class Form extends Component {
     } = this.props;
     const modelValue = _get(this.props, model);
 
-    e.preventDefault();
-
-    let valid = true;
-
-    mapValues(validators, (validator, field) => {
+    const valid = isValid(mapValues(validators, (validator, field) => {
       const fieldModel = [model, field].join('.');
       const value = _get(this.props, fieldModel);
       const validity = validate(validator, value);
 
-      valid = valid && isValid(validity);
-
       dispatch(actions.setValidity(fieldModel, validate(validator, value)));
-    });
+
+      return isValid(validity);
+    }));
 
     if (onSubmit && !!valid) {
       onSubmit(modelValue);
@@ -39,7 +37,14 @@ class Form extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { validators, model, dispatch } = this.props;
+    const {
+      validators,
+      model,
+      dispatch,
+      validateOn
+    } = this.props;
+
+    if (validateOn !== 'change') return;
 
     mapValues(validators, (validator, field) => {
       const fieldModel = [model, field].join('.');
@@ -55,7 +60,10 @@ class Form extends Component {
 
   render() {
     return (
-      <form {...this.props} onSubmit={(e) => this.handleSubmit(e)}>
+      <form
+        {...this.props}
+        onSubmit={(e) => this.handleSubmit(e)}
+      >
         { this.props.children }
       </form>
     );
@@ -64,6 +72,9 @@ class Form extends Component {
 
 Form.PropTypes = {
   validators: PropTypes.object,
+  validateOn: PropTypes.oneOf([
+    'change',
+  ]),
   model: PropTypes.string.isRequired
 };
 

--- a/src/components/form-component.js
+++ b/src/components/form-component.js
@@ -14,7 +14,7 @@ class Form extends Component {
     const {
       model,
       validators,
-      onSubmit = identity,
+      onSubmit,
       dispatch
     } = this.props;
     const modelValue = _get(this.props, model);
@@ -23,8 +23,7 @@ class Form extends Component {
 
     let valid = true;
 
-    Object.keys(validators).forEach((field) => {
-      const validator = validators[field];
+    mapValues(validators, (validator, field) => {
       const fieldModel = [model, field].join('.');
       const value = _get(this.props, fieldModel);
       const validity = validate(validator, value);
@@ -34,9 +33,24 @@ class Form extends Component {
       dispatch(actions.setValidity(fieldModel, validate(validator, value)));
     });
 
-    if (!valid) {
+    if (onSubmit && !!valid) {
       onSubmit(modelValue);
     }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { validators, model, dispatch } = this.props;
+
+    mapValues(validators, (validator, field) => {
+      const fieldModel = [model, field].join('.');
+      const value = _get(this.props, fieldModel);
+
+      if (value === _get(prevProps, fieldModel)) return;
+
+      const validity = validate(validator, value);
+
+      dispatch(actions.setValidity(fieldModel, validate(validator, value)));
+    });
   }
 
   render() {

--- a/src/components/form-component.js
+++ b/src/components/form-component.js
@@ -40,6 +40,7 @@ class Form extends Component {
     const {
       validators,
       model,
+      modelValue,
       dispatch,
       validateOn
     } = this.props;
@@ -78,4 +79,4 @@ Form.PropTypes = {
   model: PropTypes.string.isRequired
 };
 
-export default connect(s => s)(Form);
+export default connect(identity)(Form);

--- a/src/reducers/form-reducer.js
+++ b/src/reducers/form-reducer.js
@@ -8,6 +8,7 @@ import mapValues from 'lodash/mapValues';
 import toPath from 'lodash/toPath';
 
 import actionTypes from '../action-types';
+import { isValid } from '../utils';
 
 const initialFieldState = {
   blur: true,
@@ -188,7 +189,7 @@ function createFormReducer(model) {
         const setErrorsState = setField(state, localPath, {
           errors,
           validity,
-          valid: isBoolean(errors) ? !errors : every(errors, error => !error),
+          valid: isValid(validity),
         });
 
         return icepick.merge(setErrorsState, {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,7 @@
 import endsWith from 'lodash/endsWith';
+import mapValues from 'lodash/mapValues';
+import isPlainObject from 'lodash/isPlainObject';
+import every from 'lodash/every';
 import { initialFieldState } from '../reducers/form-reducer';
 
 function isMulti(model) {
@@ -41,6 +44,24 @@ function getValue(value) {
   return isEvent(value) ? getEventValue(value) : value;
 }
 
+function validate(validators, value) {
+  const modelValue = getValue(value);
+
+  if (typeof validators === 'function') {
+    return validators(modelValue);
+  }
+
+  return mapValues(validators, (validator) => validator(modelValue));
+}
+
+function isValid(validity) {
+  if (isPlainObject(validity)) {
+    return every(validity);
+  }
+
+  return !!validity;
+}
+
 export {
   isFocused,
   isMulti,
@@ -48,4 +69,6 @@ export {
   isTouched,
   getEventValue,
   getValue,
+  validate,
+  isValid,
 };

--- a/test/form-component-spec.js
+++ b/test/form-component-spec.js
@@ -92,4 +92,73 @@ describe('<Form> component', () => {
         });
     });
   });
+
+  describe('validation on change', () => {
+    const store = applyMiddleware(thunk)(createStore)(combineReducers({
+      testForm: createFormReducer('test'),
+      test: createModelReducer('test', { bar: '' }),
+    }));
+
+    let fooValidationCalled = false;
+
+    const form = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <Form model="test"
+          validators={{
+            foo: (val) => val && val === 'testing foo',
+            bar: {
+              one: (val) => val && val.length >= 1,
+              two: (val) => val && val.length >= 2,
+              called: () => {
+                fooValidationCalled = true;
+                return true;
+              },
+            },
+          }}
+        >
+          <Field model="test.foo">
+            <input type="text" />
+          </Field>
+
+          <Field model="test.bar">
+            <input type="text" />
+          </Field>
+        </Form>
+      </Provider>
+    );
+
+    const [fooControl] = TestUtils.scryRenderedDOMComponentsWithTag(form, 'input');
+
+    it('should validate form validators on field change', () => {
+      fooControl.value = 'invalid';
+
+      TestUtils.Simulate.change(fooControl);
+
+      assert.containSubset(
+        store.getState().testForm.fields.foo,
+        {
+          errors: true,
+          valid: false,
+        });
+
+      fooControl.value = 'testing foo';
+
+      TestUtils.Simulate.change(fooControl);
+
+      assert.containSubset(
+        store.getState().testForm.fields.foo,
+        {
+          errors: false,
+          valid: true,
+        });
+    });
+
+    it('should NOT validate fields that have not changed', () => {
+      fooControl.value = 'invalid';
+
+      TestUtils.Simulate.change(fooControl);
+
+      assert.isFalse(fooValidationCalled);
+    });
+  });
 });

--- a/test/form-component-spec.js
+++ b/test/form-component-spec.js
@@ -115,6 +115,7 @@ describe('<Form> component', () => {
               },
             },
           }}
+          validateOn="change"
         >
           <Field model="test.foo">
             <input type="text" />
@@ -153,12 +154,108 @@ describe('<Form> component', () => {
         });
     });
 
-    it('should NOT validate fields that have not changed', () => {
+    it('should NOT run validation for fields that have not changed', () => {
       fooControl.value = 'invalid';
 
       TestUtils.Simulate.change(fooControl);
 
       assert.isFalse(fooValidationCalled);
+    });
+  });
+
+  describe('onSubmit() prop', () => {
+    const store = applyMiddleware(thunk)(createStore)(combineReducers({
+      testForm: createFormReducer('test'),
+      test: createModelReducer('test'),
+    }));
+
+    let submitValue = null;
+
+    const form = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <Form model="test"
+          validators={{
+            foo: (val) => val && val === 'valid',
+          }}
+          onSubmit={(val) => (submitValue = val, true)}
+        >
+          <Field model="test.foo">
+            <input type="text" />
+          </Field>
+        </Form>
+      </Provider>
+    );
+
+    const formElement = TestUtils.findRenderedDOMComponentWithTag(form, 'form');
+
+    const control = TestUtils.findRenderedDOMComponentWithTag(form, 'input');
+
+    it('should NOT call onSubmit if form is invalid', () => {
+      TestUtils.Simulate.submit(formElement);
+
+      assert.isNull(submitValue);
+    });
+
+    it('should call onSubmit with model value if form is valid', () => {
+      control.value = 'valid';
+
+      TestUtils.Simulate.change(control);
+
+      TestUtils.Simulate.submit(formElement);
+
+      assert.deepEqual(
+        submitValue,
+        { foo: 'valid' });
+    });
+  });
+
+  describe('validation of form itself', () => {
+    const store = applyMiddleware(thunk)(createStore)(combineReducers({
+      testForm: createFormReducer('test'),
+      test: createModelReducer('test'),
+    }));
+
+    const form = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <Form model="test"
+          validators={{
+            '': {
+              foobar: (val) => val.foo + val.bar === 'foobar',
+            },
+          }}
+        >
+          <Field model="test.foo">
+            <input type="text" />
+          </Field>
+          <Field model="test.bar">
+            <input type="text" />
+          </Field>
+        </Form>
+      </Provider>
+    );
+
+    const formElement = TestUtils.findRenderedDOMComponentWithTag(form, 'form');
+
+    const [fooControl, barControl] = TestUtils.scryRenderedDOMComponentsWithTag(form, 'input');
+
+    it('should be able to set keyed validation to the form model', () => {
+      TestUtils.Simulate.submit(formElement);
+
+      assert.containSubset(
+        store.getState().testForm,
+        { valid: false });
+
+      fooControl.value = 'foo';
+      TestUtils.Simulate.change(fooControl);
+
+      barControl.value = 'bar';
+      TestUtils.Simulate.change(barControl);
+
+      TestUtils.Simulate.submit(formElement);
+
+      assert.containSubset(
+        store.getState().testForm,
+        { valid: true });
     });
   });
 });

--- a/test/form-component-spec.js
+++ b/test/form-component-spec.js
@@ -1,0 +1,53 @@
+/* eslint react/no-multi-comp:0 react/jsx-no-bind:0 */
+import { assert } from 'chai';
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+
+import { Form, createModelReducer, createFormReducer, Field } from '../src';
+
+describe('<Form> component', () => {
+  const store = applyMiddleware(thunk)(createStore)(combineReducers({
+    testForm: createFormReducer('test'),
+    test: createModelReducer('test'),
+  }));
+
+  const form = TestUtils.renderIntoDocument(
+    <Provider store={store}>
+      <Form model="test"
+        validators={{
+          foo: (val) => val === 'testing',
+        }}
+      >
+
+        <Field model="test.foo">
+          <input type="text" />
+        </Field>
+      </Form>
+    </Provider>
+  );
+
+  const formElement = TestUtils.findRenderedDOMComponentWithTag(form, 'form');
+
+  const control = TestUtils.findRenderedDOMComponentWithTag(form, 'input');
+
+  it('should validate all validators on submit', () => {
+    TestUtils.Simulate.submit(formElement);
+
+    assert.containSubset(
+      store.getState().testForm.fields.foo,
+      { valid: false });
+
+    control.value = 'testing';
+
+    TestUtils.Simulate.change(control);
+
+    TestUtils.Simulate.submit(formElement);
+
+    assert.containSubset(
+      store.getState().testForm.fields.foo,
+      { valid: true });
+  });
+});

--- a/test/form-component-spec.js
+++ b/test/form-component-spec.js
@@ -212,7 +212,10 @@ describe('<Form> component', () => {
   describe('validation of form itself', () => {
     const store = applyMiddleware(thunk)(createStore)(combineReducers({
       testForm: createFormReducer('test'),
-      test: createModelReducer('test'),
+      test: createModelReducer('test', {
+        foo: '',
+        bar: '',
+      }),
     }));
 
     const form = TestUtils.renderIntoDocument(


### PR DESCRIPTION
This PR adds the `<Form />` component with the following features:

- Validation on submit:

```js
<Form model="user"
  validators={{
    email: (val) => isValidEmail(val),
    password: (val) => isValidPassword(val)
  }}
>
  ...
</Form>
```

- Can set keyed validators of any field, even the form itself:

```js
<Form model="user"
  validators={{
    '': {
      passwordsMatch: (val) => val.password === val.confirmPassword
    },
    username: {
      required: (val) => val && val.length,
      length: (val) => val.length > 8
    }
  }}
>
  ...
</Form>
```

- Can run validators whenever fields are updated, and validators will only run for changed fields:

```js
<Form model="user"
  validators={{ ... }}
  validateOn="change"
>
```

- Will prevent `onSubmit` when form is invalid:

```js
function executeOnValidSubmit(val) {
  // ... val is the form model state
}

<Form model="user"
  validators={{ ... }}
  onSubmit={(val) => executeOnValidSubmit(val)}
>
```

- The unused and undocumented `validate()` field action was dropped.