### PR TITLE
Allow initialState to be an array.

### DIFF
--- a/src/reducers/model-reducer.js
+++ b/src/reducers/model-reducer.js
@@ -13,7 +13,15 @@ function createModeler(getter = _get, setter = icepickSet, initialModelState = {
   return function createModelReducer(model, initialState = initialModelState) {
     const modelPath = toPath(model);
 
-    return (state = initialState, action) => {
+    let initialNormalizedState = initialState;
+    if (Array.isArray(initialState)) {
+      initialNormalizedState = {};
+      initialState.forEach(value => {
+        initialNormalizedState[value] = '';
+      });
+    }
+
+    return (state = initialNormalizedState, action) => {
       if (!action.model) {
         return state;
       }
@@ -40,17 +48,17 @@ function createModeler(getter = _get, setter = icepickSet, initialModelState = {
 
         case actionTypes.RESET:
           if (!localPath.length) {
-            return initialState;
+            return initialNormalizedState;
           }
 
-          if (isEqual(getter(state, localPath), getter(initialState, localPath))) {
+          if (isEqual(getter(state, localPath), getter(initialNormalizedState, localPath))) {
             return state;
           }
 
           return setter(
             state,
             localPath,
-            getter(initialState, localPath)
+            getter(initialNormalizedState, localPath)
           );
 
         default:

--- a/test/model-reducer-spec.js
+++ b/test/model-reducer-spec.js
@@ -16,6 +16,15 @@ describe('createModelReducer()', () => {
       { foo: 'bar' });
   });
 
+  it('should create a reducer with initial state given a model and initial state as an array',
+    () => {
+      const reducer = createModelReducer('test', ['foo', 'bar']);
+
+      assert.deepEqual(
+        reducer(undefined, {}),
+        { foo: '', bar: '' });
+    });
+
   it('should ignore external actions', () => {
     const model = { foo: 'bar' };
     const reducer = createModelReducer('test', model);


### PR DESCRIPTION
Allows for less boilerplate for createModelReducer's initial state.

``` javascript
const initialUser = ['firstName', 'lastName', 'email'];
```

Will return the initial state:
``` javascript
{
  firstName: '',
  lastName: '',
  email: '',
}
```

