### PR TITLE
fix validate error with blank props.errors

### DIFF
--- a/src/components/field-component.js
+++ b/src/components/field-component.js
@@ -136,11 +136,8 @@ function sequenceEventActions(control, props) {
 
   if (props.validators || props.errors) {
     const dispatchValidate = value => {
-      const validity = getValidity(props.validators, value);
-      const errors = getValidity(props.errors, value);
-
-      dispatch(setValidity(model, validity));
-      dispatch(setErrors(model, errors));
+      props.validators && dispatch(setValidity(model, getValidity(props.validators, value)));
+      props.errors && dispatch(setErrors(model, getValidity(props.errors, value)));
 
       return value;
     };

--- a/src/components/field-component.js
+++ b/src/components/field-component.js
@@ -135,11 +135,11 @@ function sequenceEventActions(control, props) {
   if (props.validators || props.errors) {
     const dispatchValidate = value => {
       if (props.validators) {
-        dispatch(setValidity(model, getValidity(props.validators, value)));
+        dispatch(actions.validate(model, props.validators, value));
       }
 
       if (props.errors) {
-        dispatch(setErrors(model, getValidity(props.errors, value)));
+        dispatch(actions.validateErrors(model, props.errors, value));
       }
 
       return value;

--- a/src/components/field-component.js
+++ b/src/components/field-component.js
@@ -136,8 +136,13 @@ function sequenceEventActions(control, props) {
 
   if (props.validators || props.errors) {
     const dispatchValidate = value => {
-      props.validators && dispatch(setValidity(model, getValidity(props.validators, value)));
-      props.errors && dispatch(setErrors(model, getValidity(props.errors, value)));
+      if (props.validators) {
+        dispatch(setValidity(model, getValidity(props.validators, value)));
+      }
+
+      if (props.errors) {
+        dispatch(setErrors(model, getValidity(props.errors, value)));
+      }
 
       return value;
     };


### PR DESCRIPTION
When I do not set ```Field.props.errors```, it will validate error and set ```valid: true```