### PR TITLE
Add action creator to move an array item from one index to another

### DIFF
--- a/src/actions/model-actions.js
+++ b/src/actions/model-actions.js
@@ -96,6 +96,11 @@ const remove = (model, index) => (dispatch, getState) => {
 
 const move = (model, indexFrom, indexTo) => (dispatch, getState) => {
   const collection = _get(getState(), model, []);
+
+  if (indexFrom >= collection.length || indexTo >= collection.length) {
+    return;
+  }
+
   const item = collection[indexFrom];
   const removed = icepick.splice(collection, indexFrom, 1);
   const inserted = icepick.splice(removed, indexTo, 0, item);

--- a/src/actions/model-actions.js
+++ b/src/actions/model-actions.js
@@ -94,6 +94,19 @@ const remove = (model, index) => (dispatch, getState) => {
   });
 };
 
+const move = (model, indexFrom, indexTo) => (dispatch, getState) => {
+  const collection = _get(getState(), model, []);
+  const item = collection[indexFrom];
+  const removed = icepick.splice(collection, indexFrom, 1);
+  const inserted = icepick.splice(removed, indexTo, 0, item);
+
+  dispatch({
+    type: actionTypes.CHANGE,
+    model,
+    value: inserted,
+  });
+};
+
 const merge = (model, values) => (dispatch, getState) => {
   const value = _get(getState(), model, {});
 
@@ -111,6 +124,7 @@ export default {
   merge,
   push,
   remove,
+  move,
   reset,
   toggle,
   xor,

--- a/src/components/field-component.js
+++ b/src/components/field-component.js
@@ -82,8 +82,12 @@ function isReadOnlyValue(control) {
     && ~['radio', 'checkbox'].indexOf(control.props.type);
 }
 
+function checkboxChangeAction(props) {
+  return isMulti(props.model) ? xor : toggle;
+}
+
 const changeActionMap = {
-  checkbox: (props) => isMulti(props.model) ? xor : toggle,
+  checkbox: checkboxChangeAction,
   default: () => change,
 };
 

--- a/test/actions-spec.js
+++ b/test/actions-spec.js
@@ -280,6 +280,34 @@ describe('model action creators', () => {
 
       fn(dispatch, getState);
     });
+
+    it('should ignore invalid from index', () => {
+      const fn = actions.move('foo.bar', 4, 0);
+      const dispatch = () => {
+        assert.fail('Should not dispatch action');
+      };
+      const getState = () => ({
+        foo: {
+          bar: [1, 2, 3, 4],
+        },
+      });
+
+      fn(dispatch, getState);
+    });
+
+    it('should ignore invalid to index', () => {
+      const fn = actions.move('foo.bar', 3, 4);
+      const dispatch = () => {
+        assert.fail('Should not dispatch action');
+      };
+      const getState = () => ({
+        foo: {
+          bar: [1, 2, 3, 4],
+        },
+      });
+
+      fn(dispatch, getState);
+    });
   });
 });
 

--- a/test/actions-spec.js
+++ b/test/actions-spec.js
@@ -245,6 +245,42 @@ describe('model action creators', () => {
       fn(dispatch, getState);
     });
   });
+
+  describe('actions.move() thunk', () => {
+    it('should return a function that dispatches a change event', done => {
+      const fn = actions.move('foo.bar', 2, 0);
+      const dispatch = action => {
+        done(assert.equal(
+          action.type,
+          actionTypes.CHANGE));
+      };
+      const getState = () => ({
+        foo: {
+          bar: [1, 2, 3, 4],
+        },
+      });
+
+      assert.isFunction(fn);
+
+      fn(dispatch, getState);
+    });
+
+    it('should change a collection by moving the item to the specified index', done => {
+      const fn = actions.move('foo.bar', 2, 0);
+      const dispatch = action => {
+        done(assert.deepEqual(
+          action.value,
+          [3, 1, 2, 4]));
+      };
+      const getState = () => ({
+        foo: {
+          bar: [1, 2, 3, 4],
+        },
+      });
+
+      fn(dispatch, getState);
+    });
+  });
 });
 
 describe('RSF field action creators', () => {

--- a/test/model-actions-spec.js
+++ b/test/model-actions-spec.js
@@ -132,6 +132,11 @@ describe('model actions', () => {
           params: ['test.foo', 0, 2],
           expected: { foo: ['second', 'third', 'first'] },
         },
+        {
+          init: { foo: [] },
+          params: ['test.foo', 0, 2],
+          expected: { foo: [] },
+        },
       ],
       merge: [
         {
@@ -147,16 +152,17 @@ describe('model actions', () => {
       describe(`${action}()`, () => {
         actionTests[action].map(test => {
           const { init, params, expected } = test;
-          it('should modify the model to the expected result', done => {
+          it('should modify the model to the expected result', () => {
             const reducer = modelReducer('test');
+            let actual = init;
             const dispatch = _action => {
-              done(assert.deepEqual(
-                reducer(init, _action),
-                expected));
+              actual = reducer(init, _action);
             };
             const getState = () => ({ test: init });
 
             actions[action](...params)(dispatch, getState);
+
+            assert.deepEqual(actual, expected);
           });
         });
       });

--- a/test/model-actions-spec.js
+++ b/test/model-actions-spec.js
@@ -121,6 +121,13 @@ describe('model actions', () => {
           expected: { foo: ['first', 'third'] },
         },
       ],
+      move: [
+        {
+          init: { foo: ['first', 'second', 'third'] },
+          params: ['test.foo', 2, 1],
+          expected: { foo: ['first', 'third', 'second'] },
+        },
+      ],
       merge: [
         {
           init: { foo: { bar: 'baz', untouched: 'intact' } },

--- a/test/model-actions-spec.js
+++ b/test/model-actions-spec.js
@@ -127,6 +127,11 @@ describe('model actions', () => {
           params: ['test.foo', 2, 1],
           expected: { foo: ['first', 'third', 'second'] },
         },
+        {
+          init: { foo: ['first', 'second', 'third'] },
+          params: ['test.foo', 0, 2],
+          expected: { foo: ['second', 'third', 'first'] },
+        },
       ],
       merge: [
         {


### PR DESCRIPTION
Implemented in terms of change similar to push and remove.

Wonder if this is the most efficient way to do this?  Not clear enough on exactly what icepick is doing, but I wonder if this is causing more clones than necessary?  Maybe adding direct support to the reducer to call icepick splice would be more efficient?

For the scenario where the to/from indices are out of bounds of the array I've chosen to silently ignore the action (i.e. don't call dispatch) as in the case of an empty array this seemed to cause the array's state value to end up wtih an 'undefined' entry.

Also tweaked some of the model-actions-spec tests. They were using async (done) handling which seems unncessary for these tests as there is nothing async happening? And this prevented me from writing an empty array out of bounds test for the move action because it doesn't call dispatch.