### PR TITLE
When swapping fields in the DOM text input value was preserved from the previous control.

### DIFF
--- a/src/components/field-component.js
+++ b/src/components/field-component.js
@@ -56,7 +56,7 @@ const controlPropsMap = {
   }),
   text: (props) => ({
     ...props,
-    defaultValue: props.modelValue,
+    value: props.modelValue,
     name: props.model,
   }),
   textarea: (props) => controlPropsMap.text(props),

--- a/test/field-component-spec.js
+++ b/test/field-component-spec.js
@@ -1,5 +1,6 @@
 /* eslint react/no-multi-comp:0 react/jsx-no-bind:0 */
 import React, { PropTypes } from 'react';
+import ReactDOM from 'react-dom';
 import { assert } from 'chai';
 import { createStore, applyMiddleware, combineReducers } from 'redux';
 import { Provider, connect } from 'react-redux';
@@ -1094,6 +1095,49 @@ describe('<Field /> component', () => {
       assert.equal(
         store.getState().test.foo,
         'testing');
+    });
+  });
+
+  describe('swapping fields', () => {
+    const reducer = modelReducer('test', { a: 'a value', b: 'b value' });
+    const store = applyMiddleware(thunk)(createStore)(combineReducers({
+      test: reducer,
+    }));
+
+    const ToggleFields = ({ field }) => (
+      field === 'a'
+      ? <Field
+        model="test.a"
+      >
+        <input type="text" />
+      </Field>
+      : <Field
+        model="test.b"
+      >
+        <input type="text" />
+      </Field>);
+
+    ToggleFields.propTypes = { field: PropTypes.string.isRequired };
+
+    it('should change the value of the control', () => {
+      const toggle = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <ToggleFields field="a" />
+        </Provider>,
+      );
+
+      const control = TestUtils.findRenderedDOMComponentWithTag(toggle, 'input');
+      assert.equal(control.value, 'a value');
+
+      ReactDOM.render(
+        <Provider store={store}>
+          <ToggleFields field="b" />
+        </Provider>,
+      ReactDOM.findDOMNode(toggle).parentNode);
+
+      const newControl = TestUtils.findRenderedDOMComponentWithTag(toggle, 'input');
+      assert.equal(newControl.name, 'test.b');
+      assert.equal(newControl.value, 'b value');
     });
   });
 


### PR DESCRIPTION
This adds a test case to that effect, ensuring that when re-rendering a component that replaces one field with another, the input value after the switch is properly changed.

We fix this by making `controlPropsMap.text` pass the `modelValue` as `value` instead of `defaultValue` which is only used [on initial render](https://facebook.github.io/react/docs/forms.html#default-value).

Every other input component appears to be a controlled component so this one probably should be too.

