### PR TITLE
perform shallow compare to avoid unnecessarily re-render

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
   "dependencies": {
     "flat": "^2.0.0",
     "icepick": "^1.1.0",
-    "lodash": "^4.10.0"
+    "lodash": "^4.10.0",
+    "react-addons-shallow-compare": "^15.0.2"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",

--- a/src/components/field-component.js
+++ b/src/components/field-component.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import shallowCompare from 'react-addons-shallow-compare';
 import connect from 'react-redux/lib/components/connect';
 
 import _get from 'lodash/get';
@@ -161,6 +162,10 @@ function createFieldClass(customControlPropsMap = {}, defaultProps = {}) {
   };
 
   class Field extends Component {
+    shouldComponentUpdate(nextProps, nextState) {
+      return shallowCompare(this, nextProps, nextState);
+    }
+
     render() {
       const { props } = this;
       const component = getFieldWrapper(props);


### PR DESCRIPTION
When there is a `Form` with many `Field`s, change on one `Field` will cause all other `Field`s to re-render. (So there will be many warnings with [why-did-you-update](https://github.com/garbles/why-did-you-update))
Perform a shallow compare on `Field` could avoid these.