### PR TITLE
React 0.14.x react-addons-shallow-compare and externals

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "jsdom": "^8.0.4",
     "mocha": "^2.4.5",
     "react": "^15.0.2",
+    "react-addons-shallow-compare": "^15.0.2",
     "react-addons-test-utils": "^15.0.1",
     "react-dom": "^15.0.1",
     "react-redux": "^4.4.0",
@@ -72,11 +73,11 @@
   "dependencies": {
     "flat": "^2.0.0",
     "icepick": "^1.1.0",
-    "lodash": "^4.10.0",
-    "react-addons-shallow-compare": "^15.0.2"
+    "lodash": "^4.10.0"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",
+    "react-addons-shallow-compare": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.7 || ^15.0.0",
     "react-redux": "^4.0.0",
     "redux": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "redux-thunk": "^2.0.1",
     "should": "^8.2.2",
     "sinon": "^1.17.3",
-    "webpack": "^1.12.14"
+    "webpack": "^1.12.14",
+    "webpack-bundle-size-analyzer": "^2.0.1"
   },
   "dependencies": {
     "flat": "^2.0.0",

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -9,23 +9,35 @@ module.exports = {
       commonjs: 'react',
       amd: 'react',
     },
-    redux: {
-      root: 'Redux',
-      commonjs2: 'redux',
-      commonjs: 'redux',
-      amd: 'redux',
-    },
     'react-addons-shallow-compare': {
       root: 'react-addons-shallow-compare',
       commonjs2: 'react-addons-shallow-compare',
       commonjs: 'react-addons-shallow-compare',
       amd: 'react-addons-shallow-compare',
     },
+    'react-dom': {
+      root: 'react-dom',
+      commonjs2: 'react-dom',
+      commonjs: 'react-dom',
+      amd: 'react-dom',
+    },
     'react-redux': {
       root: 'ReactRedux',
       commonjs2: 'react-redux',
       commonjs: 'react-redux',
       amd: 'react-redux',
+    },
+    redux: {
+      root: 'Redux',
+      commonjs2: 'redux',
+      commonjs: 'redux',
+      amd: 'redux',
+    },
+    'redux-thunk': {
+      root: 'redux-thunk',
+      commonjs2: 'redux-thunk',
+      commonjs: 'redux-thunk',
+      amd: 'redux-thunk',
     },
   },
   module: {

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -15,6 +15,12 @@ module.exports = {
       commonjs: 'redux',
       amd: 'redux',
     },
+    'react-addons-shallow-compare': {
+      root: 'react-addons-shallow-compare',
+      commonjs2: 'react-addons-shallow-compare',
+      commonjs: 'react-addons-shallow-compare',
+      amd: 'react-addons-shallow-compare',
+    },
     'react-redux': {
       root: 'ReactRedux',
       commonjs2: 'react-redux',


### PR DESCRIPTION
I believe react-addons-shallow-compare should be a peerDep because it will potentially break React 0.14.x compatibility otherwise and also isn't needed if not using <Field.

I made sure all peerDeps were listed as an external. Also found a missing devDep webpack-bundle-size-analyzer