### PR TITLE
Fixing performance issues

### DIFF
--- a/test/field-component-spec.js
+++ b/test/field-component-spec.js
@@ -1542,8 +1542,12 @@ describe('<Field /> component', () => {
     const components = TestUtils.findAllInRenderedTree(field, filter);
     assert.lengthOf(components, 1, 'exactly one connected Control was rendered');
     const [component] = components;
-    assert.isFalse(
-      component.updateStatePropsIfNeeded(),
-      'component does not need to update its state props with constant state');
+    const oldStateProps = component.stateProps;
+    const didUpdate = component.updateStatePropsIfNeeded();
+    const failures = Object.keys(component.stateProps).filter((k) =>
+      component.stateProps[k] !== oldStateProps[k]);
+    assert(
+      !didUpdate,
+      `stateProps should not have changed, changed props: ${failures.join(', ')}`);
   });
 });

--- a/test/field-component-spec.js
+++ b/test/field-component-spec.js
@@ -1537,7 +1537,7 @@ describe('<Field /> component', () => {
         </Field>
       </Provider>
     );
-    const filter = ({constructor}) =>
+    const filter = ({ constructor }) =>
       constructor.displayName === 'Connect(Control)';
     const components = TestUtils.findAllInRenderedTree(field, filter);
     assert.lengthOf(components, 1, 'exactly one connected Control was rendered');

--- a/test/field-component-spec.js
+++ b/test/field-component-spec.js
@@ -1524,4 +1524,26 @@ describe('<Field /> component', () => {
 
     assert.equal(input.value, 'changed');
   });
+
+  it('should render a Component with an idempotent mapStateToProps', () => {
+    const store = applyMiddleware(thunk)(createStore)(combineReducers({
+      test: modelReducer('test', { foo: '' }),
+    }));
+
+    const field = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <Field model="test.foo">
+          <input />
+        </Field>
+      </Provider>
+    );
+    const filter = ({constructor}) =>
+      constructor.displayName === 'Connect(Control)';
+    const components = TestUtils.findAllInRenderedTree(field, filter);
+    assert.lengthOf(components, 1, 'exactly one connected Control was rendered');
+    const [component] = components;
+    assert.isFalse(
+      component.updateStatePropsIfNeeded(),
+      'component does not need to update its state props with constant state');
+  });
 });


### PR DESCRIPTION
@etrepum This PR moves the prop mapping to the internal `<Control>` state, which prevents it from recreating the mapped props _unless_ the field/control is supposed to rerender, anyway.