### PR TITLE
Add a runnable `npm run examples` server

### DIFF
--- a/examples/global.css
+++ b/examples/global.css
@@ -1,0 +1,20 @@
+body {
+  font-family: "Helvetica Neue", Arial;
+  font-weight: 200;
+}
+
+h1, h2, h3 {
+  font-weight: 100;
+}
+
+a {
+  color: hsl(200, 50%, 50%);
+}
+
+a.active {
+  color: hsl(20, 50%, 50%);
+}
+
+.breadcrumbs a {
+  text-decoration: none;
+}

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<title>react redux form examples</title>
+<link href="global.css" rel="stylesheet"/>
+<body>
+  <h1>react redux form examples</h1>
+  <ul>
+    <li><a href="quick-start/">Quick Start</a></li>
+  </ul>
+</body>

--- a/examples/quick-start/app.js
+++ b/examples/quick-start/app.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { Provider } from 'react-redux';
+
+// We'll create this in Step 5.
+import store from './store.js';
+
+// We'll create this in Step 6.
+import UserForm from './components/user-form.js';
+
+class App extends React.Component {
+  render() {
+    return (
+      <Provider store={ store }>
+        <UserForm />
+      </Provider>
+    );
+  }
+}
+
+ReactDOM.render(<App />, document.getElementById('app'));

--- a/examples/quick-start/components/user-form.js
+++ b/examples/quick-start/components/user-form.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Field, Form, actions } from 'react-redux-form';
+
+class UserForm extends React.Component {
+  handleSubmit(user) {
+    let { dispatch } = this.props;
+
+    // Do whatever you like in here.
+    // You can use actions such as:
+    // dispatch(actions.submit('user', somePromise));
+    // etc.
+  }
+  render() {
+    let { user } = this.props;
+
+    return (
+      <Form model="user"
+        onSubmit={(user) => this.handleSubmit(user)}>
+        <Field model="user.firstName">
+          <label>First name:</label>
+          <input type="text" />
+        </Field>
+
+        <Field model="user.lastName">
+          <label>Last name:</label>
+          <input type="text" />
+        </Field>
+
+        <button type="submit">
+          Finish registration, { user.firstName } { user.lastName }!
+        </button>
+      </Form>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return { user: state.user };
+}
+
+export default connect(mapStateToProps)(UserForm);

--- a/examples/quick-start/components/user-form.js
+++ b/examples/quick-start/components/user-form.js
@@ -3,20 +3,30 @@ import { connect } from 'react-redux';
 import { Field, Form, actions } from 'react-redux-form';
 
 class UserForm extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
   handleSubmit(user) {
-    let { dispatch } = this.props;
+    const { dispatch } = this.props;
 
     // Do whatever you like in here.
     // You can use actions such as:
     // dispatch(actions.submit('user', somePromise));
     // etc.
+    const somePromise = new Promise((resolve) => {
+      /* eslint-disable no-console */
+      console.log(user);
+      /* eslint-enable no-console */
+      setTimeout(() => { resolve(true); }, 1000);
+    });
+    dispatch(actions.submit('user', somePromise));
   }
   render() {
-    let { user } = this.props;
+    const { user } = this.props;
 
     return (
-      <Form model="user"
-        onSubmit={(user) => this.handleSubmit(user)}>
+      <Form model="user" onSubmit={ this.handleSubmit }>
         <Field model="user.firstName">
           <label>First name:</label>
           <input type="text" />
@@ -34,6 +44,14 @@ class UserForm extends React.Component {
     );
   }
 }
+
+UserForm.propTypes = {
+  dispatch: React.PropTypes.func.isRequired,
+  user: React.PropTypes.shape({
+    firstName: React.PropTypes.string.isRequired,
+    lastName: React.PropTypes.string.isRequired,
+  }),
+};
 
 function mapStateToProps(state) {
   return { user: state.user };

--- a/examples/quick-start/index.html
+++ b/examples/quick-start/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<link href="/global.css" rel="stylesheet"/>
+<title>Quick Start - react redux form examples</title>
+<body>
+  <h1 class="breadcrumbs"><a href="/">react redux form examples</a> / Quick Start</h1>
+  <div id="app" />
+  <script src="/__build__/shared.js"></script>
+  <script src="/__build__/quick-start.js"></script>
+</body>

--- a/examples/quick-start/store.js
+++ b/examples/quick-start/store.js
@@ -1,0 +1,23 @@
+// ./store.js
+import {
+  createStore,
+  combineReducers,
+  applyMiddleware
+} from 'redux';
+import {
+  modelReducer,
+  formReducer
+} from 'react-redux-form';
+import thunk from 'redux-thunk';
+
+const initialUserState = {
+  firstName: '',
+  lastName: ''
+};
+
+const store = applyMiddleware(thunk)(createStore)(combineReducers({
+  user: modelReducer('user', initialUserState),
+  userForm: formReducer('user', initialUserState)
+}));
+
+export default store;

--- a/examples/quick-start/store.js
+++ b/examples/quick-start/store.js
@@ -2,22 +2,22 @@
 import {
   createStore,
   combineReducers,
-  applyMiddleware
+  applyMiddleware,
 } from 'redux';
 import {
   modelReducer,
-  formReducer
+  formReducer,
 } from 'react-redux-form';
 import thunk from 'redux-thunk';
 
 const initialUserState = {
   firstName: '',
-  lastName: ''
+  lastName: '',
 };
 
 const store = applyMiddleware(thunk)(createStore)(combineReducers({
   user: modelReducer('user', initialUserState),
-  userForm: formReducer('user', initialUserState)
+  userForm: formReducer('user', initialUserState),
 }));
 
 export default store;

--- a/examples/server.js
+++ b/examples/server.js
@@ -1,29 +1,30 @@
-/*eslint-disable no-console, no-var */
-var express = require('express')
-var rewrite = require('express-urlrewrite')
-var webpack = require('webpack')
-var webpackDevMiddleware = require('webpack-dev-middleware')
-var WebpackConfig = require('./webpack.config')
+/* eslint-disable no-console, no-var, prefer-arrow-callback, func-names, prefer-template */
+var express = require('express');
+var rewrite = require('express-urlrewrite');
+var webpack = require('webpack');
+var webpackDevMiddleware = require('webpack-dev-middleware');
+var WebpackConfig = require('./webpack.config');
 
-var app = express()
+var fs = require('fs');
+var path = require('path');
+
+var app = express();
 
 app.use(webpackDevMiddleware(webpack(WebpackConfig), {
   publicPath: '/__build__/',
   stats: {
-    colors: true
-  }
-}))
-
-var fs = require('fs')
-var path = require('path')
+    colors: true,
+  },
+}));
 
 fs.readdirSync(__dirname).forEach(function (file) {
-  if (fs.statSync(path.join(__dirname, file)).isDirectory())
-    app.use(rewrite('/' + file + '/*', '/' + file + '/index.html'))
-})
+  if (fs.statSync(path.join(__dirname, file)).isDirectory()) {
+    app.use(rewrite('/' + file + '/*', '/' + file + '/index.html'));
+  }
+});
 
-app.use(express.static(__dirname))
+app.use(express.static(__dirname));
 
 app.listen(8080, function () {
-  console.log('Server listening on http://localhost:8080, Ctrl+C to stop')
-})
+  console.log('Server listening on http://localhost:8080, Ctrl+C to stop');
+});

--- a/examples/server.js
+++ b/examples/server.js
@@ -1,0 +1,29 @@
+/*eslint-disable no-console, no-var */
+var express = require('express')
+var rewrite = require('express-urlrewrite')
+var webpack = require('webpack')
+var webpackDevMiddleware = require('webpack-dev-middleware')
+var WebpackConfig = require('./webpack.config')
+
+var app = express()
+
+app.use(webpackDevMiddleware(webpack(WebpackConfig), {
+  publicPath: '/__build__/',
+  stats: {
+    colors: true
+  }
+}))
+
+var fs = require('fs')
+var path = require('path')
+
+fs.readdirSync(__dirname).forEach(function (file) {
+  if (fs.statSync(path.join(__dirname, file)).isDirectory())
+    app.use(rewrite('/' + file + '/*', '/' + file + '/index.html'))
+})
+
+app.use(express.static(__dirname))
+
+app.listen(8080, function () {
+  console.log('Server listening on http://localhost:8080, Ctrl+C to stop')
+})

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -1,0 +1,44 @@
+/*eslint-disable no-var */
+var fs = require('fs')
+var path = require('path')
+var webpack = require('webpack')
+
+module.exports = {
+
+  devtool: 'inline-source-map',
+
+  entry: fs.readdirSync(__dirname).reduce(function (entries, dir) {
+    if (fs.statSync(path.join(__dirname, dir)).isDirectory())
+      entries[dir] = path.join(__dirname, dir, 'app.js')
+
+    return entries
+  }, {}),
+
+  output: {
+    path: __dirname + '/__build__',
+    filename: '[name].js',
+    chunkFilename: '[id].chunk.js',
+    publicPath: '/__build__/'
+  },
+
+  module: {
+    loaders: [
+      { test: /\.js$/, exclude: /node_modules/, loader: 'babel' },
+      { test: /\.css$/, loader: 'style!css' }
+    ]
+  },
+
+  resolve: {
+    alias: {
+      'react-redux-form': path.join(__dirname, '..', 'src')
+    }
+  },
+
+  plugins: [
+    new webpack.optimize.CommonsChunkPlugin('shared.js'),
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development')
+    })
+  ]
+
+};

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "start": "npm run build",
+    "examples": "node examples/server.js",
     "lint": "eslint --ext .js,.jsx .",
     "lint:fix": "eslint --fix --ext .js,.jsx .",
     "test": "NODE_ENV=test mocha --require babel-register --require ./test/spec-setup.js",
@@ -49,11 +50,14 @@
     "babel-register": "^6.5.2",
     "chai": "^3.5.0",
     "chai-subset": "^1.2.1",
+    "css-loader": "^0.23.1",
     "eslint": "^2.7.0",
     "eslint-config-airbnb": "^7.0.0",
     "eslint-plugin-jsx-a11y": "^0.6.2",
     "eslint-plugin-react": "^4.3.0",
     "estraverse-fb": "^1.3.1",
+    "express": "^4.13.4",
+    "express-urlrewrite": "^1.2.0",
     "immutable": "^3.7.6",
     "jsdom": "^9.2.0",
     "mocha": "^2.5.1",
@@ -67,8 +71,10 @@
     "redux-thunk": "^2.0.1",
     "should": "^8.2.2",
     "sinon": "^1.17.3",
+    "style-loader": "^0.13.1",
     "webpack": "^1.12.14",
-    "webpack-bundle-size-analyzer": "^2.0.1"
+    "webpack-bundle-size-analyzer": "^2.0.1",
+    "webpack-dev-middleware": "^1.6.1"
   },
   "dependencies": {
     "flat": "^2.0.0",


### PR DESCRIPTION
Add a runnable `npm run examples` server for live examples of rrf, starting with the quick-start example.

Used https://github.com/reactjs/react-router/tree/master/examples as a template.