### PR TITLE
Possible fixes for umd build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:watch": "NODE_ENV=test mocha -w --require babel-register --require ./test/spec-setup.js",
     "build": "npm run build:umd && npm run build:lib",
     "build:watch": "babel -w src --out-dir lib",
-    "build:umd": "webpack -p src/index.js umd/ReactReduxForm.js --config webpack.config.prod.js",
+    "build:umd": "webpack -p src/index.js umd/ReactReduxForm.min.js --config webpack.config.prod.js",
     "build:lib": "babel src --out-dir lib",
     "analyze": "webpack src/index.js dist/index.js --config webpack.config.prod.js --json > stats.json",
     "preversion": "npm run test && npm run lint",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:watch": "NODE_ENV=test mocha -w --require babel-register --require ./test/spec-setup.js",
     "build": "npm run build:umd && npm run build:lib",
     "build:watch": "babel -w src --out-dir lib",
-    "build:umd": "webpack -p src/index.js dist/index.js --config webpack.config.prod.js",
+    "build:umd": "webpack -p src/index.js umd/ReactReduxForm.js --config webpack.config.prod.js",
     "build:lib": "babel src --out-dir lib",
     "analyze": "webpack src/index.js dist/index.js --config webpack.config.prod.js --json > stats.json",
     "preversion": "npm run test && npm run lint",

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -46,7 +46,7 @@ module.exports = {
     ],
   },
   output: {
-    library: 'react-redux-form',
+    library: 'ReactReduxForm',
     libraryTarget: 'umd',
   },
   resolve: {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -10,12 +10,6 @@ const config = Object.create(baseConfig);
 
 Object.assign(config, {
   entry: path.join(__dirname, 'src/index.js'),
-
-  output: {
-      path: path.resolve('./dist/'),
-      // publicPath: path.resolve('./build'),
-      filename: "build.js",
-  },
 });
 
 config.plugins = config.plugins.concat([


### PR DESCRIPTION
#334 

This is just one possible solution.

The current react-redux-form build has a webpack.config.base.js and a webpack.config.prod.js.

It wasn't clear to me what the goal of these two configs were, but the issue I was having with the umd build seemed to be related to having duplicated output sections and also specifying the output file both on the command line (in package.json) and in the prod output section.

So I removed the prod output section.  I also had to rename the output lib to 'ReactReduxForm' from 'react-redux-form' as I had an issue referencing a name with hyphens in my own project's webpack externals.  But that could be because I am doing it wrong.

