### PR TITLE
v1 Fix deep-compare-children for `false` children.

### DIFF
--- a/src/utils/deep-compare-children.js
+++ b/src/utils/deep-compare-children.js
@@ -18,6 +18,12 @@ function compareChildren(props, nextProps) {
   const childrenArray = React.Children.toArray(children);
   const nextChildrenArray = React.Children.toArray(nextChildren);
 
+  // React.Children.toArray strip's `false` children so lengths
+  // can change
+  if (childrenArray.length !== nextChildrenArray.length) {
+    return false;
+  }
+
   return [].concat(childrenArray)
     .some((child, i) => {
       const nextChild = nextChildrenArray[i];


### PR DESCRIPTION
React.Children.toArray filters out `false` children, so it can't
be assumed that lengths are the same afterwards, if children length
was equal.

I couldn't see any unit tests for this file unfortunately, but an example of something that breaks this would be changing the `showOne` `showTwo` props of the following:

```javascript
render() {
  return (<Form>
    {this.props.showOne && <div>One is shown</div>}
    {this.props.showTwo && <div>Two is shown</div>}
  </Form>)
}
```