### PR TITLE
v1 Handle Form validators / errors props changing.

### DIFF
--- a/src/components/form-component.js
+++ b/src/components/form-component.js
@@ -72,14 +72,16 @@ class Form extends Component {
 
   validate(nextProps, initial = false) {
     const {
-      validators,
-      errors,
       model,
       dispatch,
       formValue,
       modelValue,
     } = this.props;
 
+    const {
+      validators,
+      errors,
+    } = nextProps;
 
     if (!formValue) return;
 
@@ -90,6 +92,8 @@ class Form extends Component {
 
       return;
     }
+
+    const validatorsChanged = validators !== this.props.validators || errors !== this.props.errors;
 
     let validityChanged = false;
 
@@ -104,7 +108,7 @@ class Form extends Component {
 
       const currentValidity = getField(formValue, field).validity;
 
-      if (!initial && (nextValue === currentValue)) {
+      if ((!initial && !validatorsChanged) && (nextValue === currentValue)) {
         return currentValidity;
       }
 
@@ -128,7 +132,7 @@ class Form extends Component {
 
       const currentErrors = getField(formValue, field).errors;
 
-      if (!initial && (nextValue === currentValue)) {
+      if ((!initial && !validatorsChanged) && (nextValue === currentValue)) {
         return getField(formValue, field).errors;
       }
 

--- a/test/form-component-spec.js
+++ b/test/form-component-spec.js
@@ -1395,4 +1395,74 @@ describe('<Form> component', () => {
       assert.ok(TestUtils.findRenderedDOMComponentWithClass(form, 'focused'));
     });
   });
+
+  describe('validation on validation prop change', () => {
+    const store = applyMiddleware(thunk)(createStore)(combineReducers({
+      testForm: formReducer('test'),
+      test: modelReducer('test', {
+        foo: '',
+        bar: '',
+      }),
+    }));
+
+    let timesOneValidationCalled = 0;
+    let timesTwoValidationCalled = 0;
+
+    class ValidationChanger extends React.Component {
+      constructor() {
+        super();
+        this.state = { validateOne: true };
+      }
+
+      toggleValidateOne = () => {
+        this.setState({ validateOne: !this.state.validateOne });
+      };
+
+      validators() {
+        if (this.state.validateOne) {
+          return {
+            foo: () => {
+              timesOneValidationCalled += 1;
+              return true;
+            },
+          };
+        }
+        return {
+          foo: () => {
+            timesTwoValidationCalled += 1;
+            return true;
+          },
+        };
+      }
+
+      render() {
+        return (
+          <Provider store={store}>
+            <Form model="test" validators={this.validators()}>
+              <Field model="test.foo">
+                <input type="text" />
+              </Field>
+              <button onClick={this.toggleValidateOne}>Toggle One Validate</button>
+            </Form>
+          </Provider>
+        );
+      }
+    }
+
+    const form = TestUtils.renderIntoDocument(<ValidationChanger />);
+
+    const [toggleButton] = TestUtils.scryRenderedDOMComponentsWithTag(form, 'button');
+
+    it('should validate form validators initially on load', () => {
+      assert.equal(timesOneValidationCalled, 1);
+      assert.equal(timesTwoValidationCalled, 0);
+    });
+
+    it('should revalidate on form validators changing', () => {
+      TestUtils.Simulate.click(toggleButton);
+
+      assert.equal(timesOneValidationCalled, 1);
+      assert.equal(timesTwoValidationCalled, 1);
+    });
+  });
 });


### PR DESCRIPTION
The Form component previously was using the old validators / errors props when they changed to check validation.
Swapped to using the new validators and errors props for checking new validation on props changes.

( #377 but for v1 beta)