### PR TITLE
Fixed error in Validation example

### DIFF
--- a/examples/validation/components/user-form.js
+++ b/examples/validation/components/user-form.js
@@ -75,7 +75,7 @@ class UserForm extends React.Component {
             show={{ pristine: false }}
             model="user.dob"
             messages={{
-              lessThan: (value, { lessThan }) => `Error: ${value} is not less than ${lessThan}`,
+              lessThan10: (value, { lessThan }) => `Error: ${value} is not less than ${lessThan}`,
             }}
           />
         </Field>


### PR DESCRIPTION
Fixed error in Validation example where message key was not finding a match in the errors object