### PR TITLE
Typescript FieldProps extends ControlPropsextends HTMLProps. Fixes #552

### DIFF
--- a/react-redux-form.d.ts
+++ b/react-redux-form.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-redux-form v1.2.2
+// Type definitions for react-redux-form
 // Project: https://github.com/davidkpiano/react-redux-form
 // Definitions by: Robert Parker (Flavorus) <https://github.com/hsrobflavorus>, Flavorus <http://www.flavorus.com>, Alexey Svetliakov (@asvetliakov), Zach Waggoner <https://github.com/zach-waggoner>
 
@@ -87,7 +87,21 @@ interface CustomComponentProps extends WrapperProps {
     children: any;
 }
 
-export interface FieldProps {
+interface MapPropsProps {
+  onChange: (event: any) => void;
+  onBlur: (event: any) => void;
+  onFocus: (event: any) => void;
+  fieldValue: FieldState;
+  modelValue: any;
+  viewValue: any;
+}
+
+type MapPropsFunc = (props: MapPropsProps) => any;
+type MapPropsObject = { [key: string]: (props: MapPropsProps) => any };
+
+type MapProps = MapPropsFunc | MapPropsObject;
+
+export interface ControlProps<T> extends React.HTMLProps<T> {
     /**
      * Wrap field into custom component
      */
@@ -168,44 +182,70 @@ export interface FieldProps {
      * @param value The value that the model is being changed to
      */
     changeAction?: (model: string, value: any) => void;
-}
-
-export class Field extends React.Component<FieldProps, {}> {
-
-}
-
-interface MapPropsProps {
-  onChange: (event: any) => void;
-  onBlur: (event: any) => void;
-  onFocus: (event: any) => void;
-  fieldValue: FieldState;
-  modelValue: any;
-  viewValue: any;
-}
-
-type MapPropsFunc = (props: MapPropsProps) => any;
-type MapPropsObject = { [key: string]: (props: MapPropsProps) => any };
-
-type MapProps = MapPropsFunc | MapPropsObject;
-
-export interface ControlProps extends FieldProps {
     /**
      * A mapping of control-specific property keys to prop-getter functions that taken in the original props and return the result prop.
      * See {@link https://davidkpiano.github.io/react-redux-form/docs/guides/custom-controls.html the documentation on custom controls} for more information.
      */
     mapProps?: MapProps;
     controlProps?: any;
+    /**
+     * Calls the callback provided to the getRef prop with the node instance. Similar to ref.
+     */
+    getRef?: () => void;
 }
 
-export class Control extends React.Component<ControlProps, {}> {
-    static input: React.ComponentClass<ControlProps>;
-    static text: React.ComponentClass<ControlProps>;
-    static textarea: React.ComponentClass<ControlProps>;
-    static radio: React.ComponentClass<ControlProps>;
-    static checkbox: React.ComponentClass<ControlProps>;
-    static file: React.ComponentClass<ControlProps>;
-    static select: React.ComponentClass<ControlProps>;
-    static reset: React.ComponentClass<ControlProps>;
+export class Control<T> extends React.Component<ControlProps<T>, {}> {
+    static input: React.ComponentClass<ControlProps<HTMLInputElement>>;
+    static text: React.ComponentClass<ControlProps<HTMLInputElement>>;
+    static textarea: React.ComponentClass<ControlProps<HTMLTextAreaElement>>;
+    static radio: React.ComponentClass<ControlProps<HTMLInputElement>>;
+    static checkbox: React.ComponentClass<ControlProps<HTMLInputElement>>;
+    static file: React.ComponentClass<ControlProps<HTMLInputElement>>;
+    static select: React.ComponentClass<ControlProps<HTMLSelectElement>>;
+    static reset: React.ComponentClass<ControlProps<HTMLButtonElement>>;
+}
+
+export interface FieldProps<T> extends ControlProps<T> {
+    /**
+     * Specifies whether the children inside <Field> are dynamic; that is, whether they are subject to change based on outside values.
+     * Default value: true. To optimize for performance, set dynamic={false} for any <Field> that does not have dynamic children.
+     * @example
+     * // Does NOT have dynamic children
+     * <Field model="user.favoriteColors" dynamic={false}>
+     *   <select>
+     *     <option value="red">red</option>
+     *     <option value="green">green</option>
+     *     <option value="blue">blue</option>
+     *   </select>
+     * </Field>
+     *
+     * // DOES have dynamic children
+     * <Field model="user.favoriteColors">
+     *   <select>
+     *     {showWhite && <option value="white">white</option>}
+     *     <option value="red">red</option>
+     *     <option value="green">green</option>
+     *     <option value="blue">blue</option>
+     *   </select>
+     * </Field>
+     *
+     * // Does NOT have dynamic children
+     * <Field model="user.state" mapProps={...} dynamic={false}>
+     *   <StatePicker />
+     * </Field>
+     *
+     * // DOES have dynamic children
+     * const { showTerritories } = this.props;
+     *
+     * <Field model="user.state" mapProps={...}>
+     *   <StatePicker territories={showTerritories} />
+     * </Field>
+     */
+    dynamic?: boolean;
+}
+
+export class Field<T> extends React.Component<FieldProps<T>, {}> {
+
 }
 
 interface BaseFormProps {
@@ -532,7 +572,7 @@ interface ComponentFieldClassPropsMappings<P> {
  * @param propsMapping
  * @param defaultProps
  */
-export function createFieldClass<P>(propsMapping: ComponentFieldClassPropsMappings<P>, defaultProps?: any): React.ComponentClass<FieldProps>;
+export function createFieldClass<P, T>(propsMapping: ComponentFieldClassPropsMappings<P>, defaultProps?: any): React.ComponentClass<FieldProps<T>>;
 
 
 interface ControlPropsMap {


### PR DESCRIPTION
Made this change but some props doesn't seem to be working on Field (`mapProps` and `controlProps`) see https://esnextb.in/?gist=94a56fd57256d44909c7cb2912fecdb6 it gives some errors on the console.

If they are not supposed to be used with `Field` I have to change the typings and the documentation should be updated.

Also found the property `componentMap` that isn't used anymore (https://github.com/davidkpiano/react-redux-form/blob/master/src/components/field-component.js#L57)