### PR TITLE
Add ability to define props passed to custom control when creating fi…

### DIFF
--- a/src/components/field-component.js
+++ b/src/components/field-component.js
@@ -102,11 +102,16 @@ function getControlType(control, props, options) {
 
 const defaultStrategy = {
   Control,
+  controPropTypes: fieldPropTypes,
   getFieldFromState,
   actions,
 };
 
 function createFieldClass(customControlPropsMap = {}, s = defaultStrategy) {
+  // Use the fieldPropTypes if no controlProptypes have been defined to
+  // maintain backwards compatibiltiy.
+  const controlPropTypes = s.controPropTypes || fieldPropTypes;
+
   function mapStateToProps(state, props) {
     const {
       model,
@@ -161,7 +166,7 @@ function createFieldClass(customControlPropsMap = {}, s = defaultStrategy) {
         mapProps = options.controlPropsMap[controlType],
       } = props;
 
-      const controlProps = pick(props, Object.keys(fieldPropTypes));
+      const controlProps = pick(props, Object.keys(controlPropTypes));
 
       if (!mapProps) {
         return React.cloneElement(
@@ -201,7 +206,7 @@ function createFieldClass(customControlPropsMap = {}, s = defaultStrategy) {
       } = this.props;
 
 
-      const allowedProps = omit(this.props, Object.keys(fieldPropTypes));
+      const allowedProps = omit(this.props, Object.keys(controlPropTypes));
       const renderableChildren = typeof children === 'function'
         ? children(fieldValue)
         : children;


### PR DESCRIPTION
Add ability to define props passed to custom control when creating field class.

This allows custom control classes with extra props to be created that can then leverage the createFieldClass method to pass the correct props. 