### PR TITLE
tweaks to resetValidity

### DIFF
--- a/src/components/control-component.js
+++ b/src/components/control-component.js
@@ -183,7 +183,7 @@ function createControlClass(customControlPropsMap = {}, s = defaultStrategy) {
         const keys = Object.keys(validators)
           .concat(Object.keys(errors), this.willValidate ? validityKeys : []);
 
-        dispatch(actions.setValidity(model, omit(fieldValue.validity, keys)));
+        dispatch(actions.resetValidity(model, keys));
       }
     }
 

--- a/src/reducers/form-actions-reducer.js
+++ b/src/reducers/form-actions-reducer.js
@@ -196,19 +196,22 @@ export default function formActionsReducer(state, action, localPath) {
     case actionTypes.RESET_VALIDITY: {
       let validity = { ...fieldState.validity };
       let errors = { ...fieldState.errors };
+      let valid;
 
       if (action.omitKeys) {
         action.omitKeys.forEach((key) => {
           delete validity[key];
           delete errors[key];
         });
+        valid = isValidityValid(validity);
       } else {
         validity = initialFieldState.validity;
         errors = initialFieldState.errors;
+        valid = initialFieldState.valid;
       }
 
       fieldUpdates = {
-        valid: initialFieldState.valid,
+        valid,
         validity,
         errors,
       };

--- a/test/control-component-spec.js
+++ b/test/control-component-spec.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
-import { connect, Provider } from 'react-redux';
+import { Provider } from 'react-redux';
 import sinon from 'sinon';
 import capitalize from '../src/utils/capitalize';
 import _get from 'lodash.get';

--- a/test/field-component-spec.js
+++ b/test/field-component-spec.js
@@ -1995,6 +1995,42 @@ Object.keys(testContexts).forEach((testKey) => {
 
         assert.isTrue(store.getState().testForm.foo.valid);
       });
+
+      it('should not clobber other non-field-specific validators', () => {
+        const initialState = {};
+        const store = testCreateStore({
+          test: modelReducer('test', initialState),
+          testForm: formReducer('test', initialState),
+        });
+
+        store.dispatch(actions.setValidity('test.foo', {
+          validator: false,
+        }));
+
+        const container = document.createElement('div');
+
+        class WrappedControl extends React.Component {
+          componentWillUnmount() {
+            store.dispatch(actions.setErrors('test.foo', {}));
+          }
+
+          render() {
+            return <Field model="test.foo" />;
+          }
+        }
+
+        ReactDOM.render(
+          <Provider store={store}>
+            <WrappedControl />
+          </Provider>,
+          container);
+
+        assert.isFalse(store.getState().testForm.foo.validity.validator);
+
+        ReactDOM.unmountComponentAtNode(container);
+
+        assert.isUndefined(store.getState().testForm.foo.validity.validator);
+      });
     });
 
     describe('with input type="reset"', () => {


### PR DESCRIPTION
I noticed your PR just now.  Unfortunately it does not fix the issue since componentWillUnmount is still calling `setValidity` and not `resetValidity`.  I changed that, but then I had to make a change to the reducer to accommodate the omitKeys parameter.  If you omit keys, it's possible that the remaining validators are still invalid, so we don't want to set the field to `true` without checking.

It took me a while, but I made a test case that demonstrates the issue I am seeing.

#580 