### PR TITLE
Field level validation replaces form level validation for same field.

### DIFF
--- a/src/reducers/form-actions-reducer.js
+++ b/src/reducers/form-actions-reducer.js
@@ -159,9 +159,31 @@ export default function formActionsReducer(state, action, localPath) {
       const isErrors = action.type === actionTypes.SET_ERRORS;
       const validity = isErrors ? action.errors : action.validity;
 
-      const inverseValidity = isPlainObject(validity)
+      console.log();
+      console.log(validity);
+
+      const validityIsPlainObject = isPlainObject(validity);
+
+      const inverseValidity = validityIsPlainObject
         ? mapValues(validity, inverse)
         : !validity;
+
+      let newErrors = {};
+      let newValidity = {};
+
+
+      if (isErrors) {
+        newErrors = validityIsPlainObject ? Object.assign({}, field.errors, validity) : validity;
+        newValidity = validityIsPlainObject ? Object.assign({}, field.validity, inverseValidity) : inverseValidity;
+      }
+      else {
+        newValidity = validityIsPlainObject ? Object.assign({}, field.validity, validity) : validity;
+        newErrors = validityIsPlainObject ? Object.assign({}, field.errors, inverseValidity) : inverseValidity;
+      }
+
+      console.log(newValidity);
+      console.log(newErrors);
+      console.log();
 
       // If the field is a form, its validity is
       // also based on whether its fields are all valid.
@@ -170,13 +192,13 @@ export default function formActionsReducer(state, action, localPath) {
         : true;
 
       fieldUpdates = {
-        [isErrors ? 'errors' : 'validity']: validity,
-        [isErrors ? 'validity' : 'errors']: inverseValidity,
+        'errors': newErrors,
+        'validity': newValidity,
         validating: false,
         validated: true,
         valid: areFieldsValid && (isErrors
-          ? !isValidityInvalid(validity)
-          : isValidityValid(validity)),
+          ? !isValidityInvalid(newErrors)
+          : isValidityValid(newValidity)),
       };
 
       parentFormUpdates = (form) => ({ valid: isValid(form) });

--- a/test/form-component-spec.js
+++ b/test/form-component-spec.js
@@ -1806,7 +1806,7 @@ Object.keys(testContexts).forEach((testKey) => {
                 required: notRequired(),
               };
               validations[field4] = {
-                required: hasValue(field4)
+                required: hasValue(field4Value)
               }
               return validations;
             }}
@@ -1897,11 +1897,11 @@ Object.keys(testContexts).forEach((testKey) => {
         
         const { $form, items } = store.getState().testForm;
 
-        assert.isFalse(items[0].name.validity.required);
-        assert.isFalse(items[0].name.validity.needsFour);
+        assert.isFalse(items[3].name.validity.required);
+        assert.isFalse(items[3].name.validity.needsFour);
 
-        assert.isTrue(items[0].name.errors.required);
-        assert.isTrue(items[0].name.errors.needsFour);
+        assert.isTrue(items[3].name.errors.required);
+        assert.isTrue(items[3].name.errors.needsFour);
 
         assert.isFalse($form.valid);
       });


### PR DESCRIPTION
There is a bug in this. If you have both a field validator and a form validator that outputs validation for a field, the field level will replace the form level.

I have added a failing test case.

I think this would have to be handled in the reducer? Could make a change to run merge over the two objects to set only validations that have changed in the dispatch. Thoughts?