### PR TITLE
Add shallowCompare to fix preact-compability

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "icepick": "^1.1.0",
     "invariant": "~2.2.1",
     "lodash.get": "~4.4.2",
-    "lodash.topath": "~4.5.2"
+    "lodash.topath": "~4.5.2",
+    "shallow-compare": "1.2.0"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",

--- a/src/utils/deep-compare-children.js
+++ b/src/utils/deep-compare-children.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import shallowCompare from 'react/lib/shallowCompare';
+import shallowCompare from 'shallow-compare';
 import shallowEqual from './shallow-equal';
 
 export function compareChildren(props, nextProps) {


### PR DESCRIPTION
This fixes a minor [preact-compat](https://github.com/developit/preact-compat) compatibility issue

* adds `shallow-compare` to package.json
* changes `react/lib/shallowCompare` to `shallow-compare` imports
