### PR TITLE
Explicitly type argument of getRef

### DIFF
--- a/react-redux-form.d.ts
+++ b/react-redux-form.d.ts
@@ -200,7 +200,7 @@ export interface ControlProps<T> extends React.HTMLProps<T> {
     /**
      * Calls the callback provided to the getRef prop with the node instance. Similar to ref.
      */
-    getRef?: (node) => void;
+    getRef?: (node: T) => void;
     /**
      * Indicates that the model's fieldValue should be passed in
      * to event handlers as the second prop.


### PR DESCRIPTION
Without an explicit type, it is implicitly defined as any. This breaks code which depends on
react-redux-form and has the `noImplicitAny` tsc flag enabled.