### PR TITLE
Add styled-components support in <Field />

### DIFF
--- a/src/components/field-component.js
+++ b/src/components/field-component.js
@@ -89,6 +89,10 @@ function getControlType(control, props, options) {
       || control.type.displayName
       || control.type.name
       || control.type;
+    
+    if (control.type.name === 'StyledComponent') {
+      controlDisplayName = control.type.target;
+    }
 
     if (controlDisplayName === 'input') {
       controlDisplayName = _controlPropsMap[control.props.type] ? control.props.type : 'text';


### PR DESCRIPTION
Hi!
First of all, thank you for the work you put into this library 🙏

I made a small change to the `<Field />` component, to add support for styled-components

[styled-components](https://github.com/styled-components/styled-components) is a popular choice for styling components.

I also made a small snippet of code for you to test:

```js
import { Field, form } from 'react-redux-form';
import { connect } from 'react-redux';
import React, { Component } from 'react';
import styled from 'styled-components';

let MyInput = styled.input`
  border: 1px solid #DDD;
  padding: 10px;
  width: 100%;
  border-radius: 2px;
`

class LoginPage extends Component {
  render () {
    return (
      <div>
        <form>
          <Field model="login.username">
            <MyInput type="text" />
          </Field>
        </form>
      </div>
    )
  }
}

const mapStateToProps = (state) => {
  return {
    login: state.forms.login
  }
}

export default connect(mapStateToProps)(LoginPage)
```

Wish you all good 😊
Asaf