### PR TITLE
Add actions.push to table of contents

### DIFF
--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -6,6 +6,7 @@
   - **Action thunk creators:**
     - [`actions.merge()`](#actions-merge)
     - [`actions.xor()`](#actions-xor)
+    - [`actions.push()`](#actions-push)
     - [`actions.toggle()`](#actions-toggle)
     - [`actions.filter()`](#actions-filter)
     - [`actions.map()`](#actions-map)


### PR DESCRIPTION
`actions.push` was missing from the table of contents of the model action creators documentation page (https://davidkpiano.github.io/react-redux-form/docs/api/actions.html)