### PR TITLE
Updated to latest version of shallow-compare

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "invariant": "~2.2.1",
     "lodash.get": "~4.4.2",
     "lodash.topath": "~4.5.2",
-    "shallow-compare": "1.2.0"
+    "shallow-compare": "1.2.1"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",


### PR DESCRIPTION
Hi, I am using this package in an existing project along with ReactBoilerplate. After trying to run a build and it failing, I did a bit of digging and found the shallow compare package version to be the issue.

Updating the latest version fixes this issue.

The issue is also discussed here: https://github.com/react-boilerplate/react-boilerplate/issues/1690