### PR TITLE
Perf improvements

### DIFF
--- a/src/components/control-component.js
+++ b/src/components/control-component.js
@@ -665,125 +665,191 @@ function createControlClass(s = defaultStrategy) {
   })(Control), ['controlProps'], ['mapProps']);
 
   /* eslint-disable react/prop-types */
-  const DefaultConnectedControl = (props) => (
-    <ConnectedControl
-      mapProps={{
-        ...controlPropsMap.default,
-        ...props.mapProps,
-      }}
-      {...omit(props, 'mapProps')}
-    />
-  );
+  /* eslint-disable react/no-multi-comp */
+  class DefaultConnectedControl extends React.Component {
+    shouldComponentUpdate(nextProps) {
+      return !shallowEqual(this.props, nextProps, {
+        deepKeys: ['controlProps'],
+        omitKeys: ['mapProps'],
+      });
+    }
+
+    render() {
+      return (
+        <ConnectedControl
+          mapProps={{
+            ...controlPropsMap.default,
+            ...this.props.mapProps,
+          }}
+          {...omit(this.props, 'mapProps')}
+        />
+      );
+    }
+  }
 
   DefaultConnectedControl.custom = ConnectedControl;
 
-  DefaultConnectedControl.input = (props) => (
-    <ConnectedControl
-      component="input"
-      mapProps={{
-        ...controlPropsMap.default,
-        ...props.mapProps,
-      }}
-      {...omit(props, 'mapProps')}
-    />
-  );
+  class DefaultConnectedControlInput extends DefaultConnectedControl {
+    render() {
+      return (
+        <ConnectedControl
+          component="input"
+          mapProps={{
+            ...controlPropsMap.default,
+            ...this.props.mapProps,
+          }}
+          {...omit(this.props, 'mapProps')}
+        />
+      );
+    }
+  }
 
-  DefaultConnectedControl.text = (props) => (
-    <ConnectedControl
-      component="input"
-      mapProps={{
-        ...controlPropsMap.text,
-        type: 'text',
-        ...props.mapProps,
-      }}
-      {...omit(props, 'mapProps')}
-    />
-  );
+  DefaultConnectedControl.input = DefaultConnectedControlInput;
 
-  DefaultConnectedControl.textarea = (props) => (
-    <ConnectedControl
-      component="textarea"
-      mapProps={{
-        ...controlPropsMap.textarea,
-        ...props.mapProps,
-      }}
-      {...omit(props, 'mapProps')}
-    />
-  );
+  class DefaultConnectedControlText extends DefaultConnectedControl {
+    render() {
+      return (
+        <ConnectedControl
+          component="input"
+          mapProps={{
+            ...controlPropsMap.text,
+            type: 'text',
+            ...this.props.mapProps,
+          }}
+          {...omit(this.props, 'mapProps')}
+        />
+      );
+    }
+  }
 
-  DefaultConnectedControl.radio = (props) => (
-    <ConnectedControl
-      component="input"
-      type="radio"
-      isToggle
-      mapProps={{
-        ...controlPropsMap.radio,
-        ...props.mapProps,
-      }}
-      {...omit(props, 'mapProps')}
-    />
-  );
+  DefaultConnectedControl.text = DefaultConnectedControlText;
 
-  DefaultConnectedControl.checkbox = (props) => (
-    <ConnectedControl
-      component="input"
-      type="checkbox"
-      isToggle
-      mapProps={{
-        ...controlPropsMap.checkbox,
-        ...props.mapProps,
-      }}
-      getValue={getCheckboxValue}
-      changeAction={props.changeAction || s.actions.checkWithValue}
-      {...omit(props, 'mapProps')}
-    />
-  );
+  class DefaultConnectedControlTextArea extends DefaultConnectedControl {
+    render() {
+      return (
+        <ConnectedControl
+          component="textarea"
+          mapProps={{
+            ...controlPropsMap.textarea,
+            ...this.props.mapProps,
+          }}
+          {...omit(this.props, 'mapProps')}
+        />
+      );
+    }
+  }
 
-  DefaultConnectedControl.file = (props) => (
-    <ConnectedControl
-      component="input"
-      type="file"
-      mapProps={{
-        ...controlPropsMap.file,
-        ...props.mapProps,
-      }}
-      {...omit(props, 'mapProps')}
-    />
-  );
+  DefaultConnectedControl.textarea = DefaultConnectedControlTextArea;
 
-  DefaultConnectedControl.select = (props) => (
-    <ConnectedControl
-      component="select"
-      mapProps={{
-        ...controlPropsMap.select,
-        ...props.mapProps,
-      }}
-      {...omit(props, 'mapProps')}
-    />
-  );
+  class DefaultConnectedControlRadio extends DefaultConnectedControl {
+    render() {
+      return (
+        <ConnectedControl
+          component="input"
+          type="radio"
+          isToggle
+          mapProps={{
+            ...controlPropsMap.radio,
+            ...this.props.mapProps,
+          }}
+          {...omit(this.props, 'mapProps')}
+        />
+      );
+    }
+  }
 
-  DefaultConnectedControl.button = (props) => (
-    <ConnectedControl
-      component="button"
-      mapProps={{
-        ...controlPropsMap.button,
-        ...props.mapProps,
-      }}
-      {...omit(props, 'mapProps')}
-    />
-  );
+  DefaultConnectedControl.radio = DefaultConnectedControlRadio;
 
-  DefaultConnectedControl.reset = (props) => (
-    <ConnectedControl
-      component="button"
-      type="reset"
-      mapProps={{
-        ...controlPropsMap.reset,
-        ...props.mapProps,
-      }}
-      {...omit(props, 'mapProps')}
-    />
-  );
+  class DefaultConnectedControlCheckbox extends DefaultConnectedControl {
+    render() {
+      return (
+        <ConnectedControl
+          component="input"
+          type="checkbox"
+          isToggle
+          mapProps={{
+            ...controlPropsMap.checkbox,
+            ...this.props.mapProps,
+          }}
+          getValue={getCheckboxValue}
+          changeAction={this.props.changeAction || s.actions.checkWithValue}
+          {...omit(this.props, 'mapProps')}
+        />
+      );
+    }
+  }
+
+  DefaultConnectedControl.checkbox = DefaultConnectedControlCheckbox;
+
+  class DefaultConnectedControlFile extends DefaultConnectedControl {
+    render() {
+      return (
+        <ConnectedControl
+          component="input"
+          type="file"
+          mapProps={{
+            ...controlPropsMap.file,
+            ...this.props.mapProps,
+          }}
+          {...omit(this.props, 'mapProps')}
+        />
+      );
+    }
+  }
+
+  DefaultConnectedControl.file = DefaultConnectedControlFile;
+
+  class DefaultConnectedControlSelect extends DefaultConnectedControl {
+    render() {
+      return (
+        <ConnectedControl
+          component="select"
+          mapProps={{
+            ...controlPropsMap.select,
+            ...this.props.mapProps,
+          }}
+          {...omit(this.props, 'mapProps')}
+        />
+      );
+    }
+  }
+
+  DefaultConnectedControl.select = DefaultConnectedControlSelect;
+
+  class DefaultConnectedControlButton extends DefaultConnectedControl {
+    render() {
+      return (
+        <ConnectedControl
+          component="button"
+          mapProps={{
+            ...controlPropsMap.button,
+            ...this.props.mapProps,
+          }}
+          {...omit(this.props, 'mapProps')}
+        />
+      );
+    }
+  }
+
+  DefaultConnectedControl.button = DefaultConnectedControlButton;
+
+  class DefaultConnectedControlReset extends DefaultConnectedControl {
+    render() {
+      return (
+        <ConnectedControl
+          component="button"
+          type="reset"
+          mapProps={{
+            ...controlPropsMap.reset,
+            ...this.props.mapProps,
+          }}
+          {...omit(this.props, 'mapProps')}
+        />
+      );
+    }
+  }
+
+  DefaultConnectedControl.reset = DefaultConnectedControlReset;
 
   return DefaultConnectedControl;
 }

--- a/src/components/control-component.js
+++ b/src/components/control-component.js
@@ -651,7 +651,18 @@ function createControlClass(s = defaultStrategy) {
     };
   }
 
-  const ConnectedControl = resolveModel(connect(mapStateToProps)(Control));
+  const ConnectedControl = resolveModel(connect(mapStateToProps, null, null, {
+    areOwnPropsEqual(ownProps, nextOwnProps) {
+      return shallowEqual(ownProps, nextOwnProps, {
+        omitKeys: ['mapProps'],
+      });
+    },
+    areStatePropsEqual(stateProps, nextStateProps) {
+      return shallowEqual(stateProps, nextStateProps, {
+        deepKeys: ['controlProps'],
+      });
+    },
+  })(Control), ['controlProps'], ['mapProps']);
 
   /* eslint-disable react/prop-types */
   const DefaultConnectedControl = (props) => (

--- a/src/utils/resolve-model.js
+++ b/src/utils/resolve-model.js
@@ -18,16 +18,21 @@ function resolveModel(model, parentModel) {
   return model;
 }
 
-export default function wrapWithModelResolver(WrappedComponent) {
+export default function wrapWithModelResolver(WrappedComponent, deepKeys = [], omitKeys = []) {
   class ResolvedModelWrapper extends ReactComponent {
     constructor(props, context) {
       super(props, context);
 
       this.model = context.model;
       this.store = context.localStore;
+      this.deepKeys = deepKeys;
+      this.omitKeys = omitKeys;
     }
     shouldComponentUpdate(nextProps) {
-      return !shallowEqual(this.props, nextProps);
+      return !shallowEqual(this.props, nextProps, {
+        deepKeys: this.deepKeys,
+        omitKeys: this.omitKeys,
+      });
     }
     render() {
       const resolvedModel = resolveModel(


### PR DESCRIPTION
We use RRF extensively at Clover Health, and we are starting to hit performance problems on really big forms. (We have health assessment forms that span several hundred questions). I did a basic performance trace using `react-addons-perf` and found that RRF itself is responsible for a lot of render calls that don't end up touching the DOM. So, I decided to take a stab at fixing these unnecessary renders.

I created a test harness of sorts here:
https://github.com/danielericlee/rrf-perf-test-harness

This is a very simple React app created via create-react-app that attaches `react-addons-perf` to a global called `window.Perf`. It creates 500 `Control.text`'s. My "benchmark" is as follows:

1. Open the console and call `Perf.start()`.
2. Click into the first text input.
3. Type "This is a test"
4. Click back into the console and call `Perf.stop()`.
5. Then, still in the console, call `Perf.printWasted()`.

Here's what `printWasted()` looks like in my benchmark for RRF version 1.10.2:
![500controlsnofix](https://cloud.githubusercontent.com/assets/943344/25114535/140851e0-23b4-11e7-8e94-7a775efb9e5b.png)

The important column here is the last one. We have three components each making 7986 calls to render that don't end up touching the DOM. I tried to address each of these.

The first commit (2288266) attacks `Connect(Control)`. This is the Component created by calling react-redux's `connect` function in `control-component`. react-redux recently added hooks for performance optimizations via an [options object](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options). I implemented `areOwnPropsEqual` and `areStatePropsEqual`, using surrounding code for inspiration as to which keys could be omitted or marked as deep. Here's the benchmark after that change:

![react-redux-connect-changes](https://cloud.githubusercontent.com/assets/943344/25114702/82195174-23b5-11e7-89f7-8f0be2b6eb3a.png)

Nice! We've reduced `Connect(Control)` from 7986 renders down to 2!

Next up, I looked at `Modeled(Connect(Control))`. I realized that this is the component returned by the call to `resolveModel` on line 654. Through a little debugging, I realized that the `resolveModel` component's `shouldComponentUpdate` was always returning true because its shallowEqual didn't omit any keys, nor mark any as deep (as control-component does). I added the ability for resolveModel to accept arrays for both `omitKeys` and `deepKeys` in its `shouldComponentUpdate`. I then pass those arrays in via the `resolveModel` invocation. (See 1a73df1).

That change resulted in an even better improvement, completely eliminating wasteful renders for `Modeled(Connect(Control))`:
![resolve-model-change](https://cloud.githubusercontent.com/assets/943344/25114821/5cafd826-23b6-11e7-92fe-240383240fb8.png)

The last change addresses the calls to `MyForm(Unknown)`. It took me a bit to figure out which component that was, but I believe it is the `Control.text` itself. To address the renders in `Control.text`, I changed it from a stateless component to a class, and added a `shouldCompomenetUpdate` equivalent to the Control component itself. I did the same for all of the `Control.*` components. (See 97182c4).

Here's the resulting trace:
![default-connected-control-change](https://cloud.githubusercontent.com/assets/943344/25114919/3cb88440-23b7-11e7-8c68-48a9674e39a4.png)

Again, `MyForm(Unknown)` is gone from the wasted render column.

With these changes, it is a night-and-day difference interacting with the 500 field form in my test harness. Prior to the changes, typing in the forms feels choppy. Tabbing through the fields is also sluggish. After the changes, typing is nearly instantaneous, and tabbing only gets a bit wonky if you hold down the tab key continuously. 

My only concern with these optimizations is that I've somehow misunderstood the values being passed to `omitKeys` and `deepKeys`. For example, I don't **truly** understand why its ok to omit `mapProps`. I really was just mimicking surrounding code, and hope that what I did made sense. Even if I'm off a little bit, I hope the performance tweaks explored here will be the starting point for getting RRF to **scream**, even on really big forms 😄 