### PR TITLE
Pass nextState to deepCompareChildren

### DIFF
--- a/src/components/field-component.js
+++ b/src/components/field-component.js
@@ -148,11 +148,11 @@ function createFieldClass(customControlPropsMap = {}, s = defaultStrategy) {
   };
 
   class Field extends Component {
-    shouldComponentUpdate(nextProps) {
+    shouldComponentUpdate(nextProps, nextState) {
       const { dynamic } = this.props;
 
       if (dynamic) {
-        return deepCompareChildren(this, nextProps);
+        return deepCompareChildren(this, nextProps, nextState);
       }
 
       return shallowCompareWithoutChildren(this, nextProps);

--- a/src/components/form-component.js
+++ b/src/components/form-component.js
@@ -103,8 +103,8 @@ function createFormClass(s = defaultStrategy) {
       }
     }
 
-    shouldComponentUpdate(nextProps) {
-      return deepCompareChildren(this, nextProps);
+    shouldComponentUpdate(nextProps, nextState) {
+      return deepCompareChildren(this, nextProps, nextState);
     }
 
     componentDidUpdate(prevProps) {


### PR DESCRIPTION
While attempting to upgrade to 1.11.0 (we're several months behind currently) we sometimes get an exception after submitting a Form. 

```
Uncaught TypeError: Cannot use 'in' operator to search for 'lastSubmitEvent' in undefined
    at n (index.js:5)
    at t.default (index.js:12)
    at o (deep-compare-children.js:59)
    at r.value (form-component.js:183)
    at f.updateComponent (ReactCompositeComponent.js:628)
    at f.performUpdateIfNecessary (ReactCompositeComponent.js:561)
    at Object.performUpdateIfNecessary (ReactReconciler.js:157)
    at s (ReactUpdates.js:150)
    at r.perform (Transaction.js:140)
    at i.perform (Transaction.js:140)
    at i.perform (ReactUpdates.js:89)
    at Object.C [as flushBatchedUpdates] (ReactUpdates.js:172)
    at r.closeAll (Transaction.js:206)
    at r.perform (Transaction.js:153)
    at Object.batchedUpdates (ReactDefaultBatchingStrategy.js:62)
    at Object.o [as batchedUpdates] (ReactUpdates.js:97)
    at dispatchEvent (ReactEventListener.js:147)
    at HTMLFormElement.r (raven.js:295)
```

It's very hard to reproduce (I have not been able write a standalone test case for it) but it is relatively simple to diagnose. It appears that if a Form's state changes without its props changing then shallowCompare tries to run `shallowDiffers(instance.state, nextState)` if `nextState` is not passed to `deepCompareChildren` then `shallowDiffers` `nextState` argument is undefined.

This PR passes `nextState` through to `deepCompareChildren` on both Field and Form components (the only two places it wasn't passed.) 

It's not clear to me that this can actually happen on `Field` since it has no state but it seemed to best to never treat these arguments as optional.