### PR TITLE
Remove references to nonexistent actionTypes.LOAD

### DIFF
--- a/docs/api/modelReducer.md
+++ b/docs/api/modelReducer.md
@@ -3,7 +3,6 @@
 Creates a `modelReducer` instance function that responds to these actions:
 
 - `actionTypes.CHANGE`
-- `actionTypes.LOAD`
 - `actionTypes.RESET`
 
 and updates the state accordingly.

--- a/src/reducers/model-reducer.js
+++ b/src/reducers/model-reducer.js
@@ -41,7 +41,6 @@ function createModeler(strategy = defaultStrategy) {
 
       switch (action.type) {
         case actionTypes.CHANGE:
-        case actionTypes.LOAD:
           if (!localPath.length) {
             return action.value;
           }


### PR DESCRIPTION
Internally the `actions.load` action creator is a specialized case of `actions.change`.