### PR TITLE
Fixed deeply dynamic model support

### DIFF
--- a/src/components/control-component.js
+++ b/src/components/control-component.js
@@ -668,13 +668,6 @@ function createControlClass(s = defaultStrategy) {
   /* eslint-disable react/prop-types */
   /* eslint-disable react/no-multi-comp */
   class DefaultConnectedControl extends React.Component {
-    shouldComponentUpdate(nextProps) {
-      return !shallowEqual(this.props, nextProps, {
-        deepKeys: ['controlProps'],
-        omitKeys: ['mapProps'],
-      });
-    }
-
     render() {
       return (
         <ConnectedControl

--- a/src/components/control-component.js
+++ b/src/components/control-component.js
@@ -668,6 +668,13 @@ function createControlClass(s = defaultStrategy) {
   /* eslint-disable react/prop-types */
   /* eslint-disable react/no-multi-comp */
   class DefaultConnectedControl extends React.Component {
+    shouldComponentUpdate(nextProps, nextState, nextContext) {
+      return !shallowEqual(this.context, nextContext) || !shallowEqual(this.props, nextProps, {
+        deepKeys: ['controlProps'],
+        omitKeys: ['mapProps'],
+      });
+    }
+
     render() {
       return (
         <ConnectedControl
@@ -680,6 +687,9 @@ function createControlClass(s = defaultStrategy) {
       );
     }
   }
+
+  // Copy the context types so that we can properly implement shouldComponentUpdate
+  DefaultConnectedControl.contextTypes = ConnectedControl.contextTypes;
 
   DefaultConnectedControl.custom = ConnectedControl;
 

--- a/src/utils/resolve-model.js
+++ b/src/utils/resolve-model.js
@@ -20,29 +20,22 @@ function resolveModel(model, parentModel) {
 
 export default function wrapWithModelResolver(WrappedComponent, deepKeys = [], omitKeys = []) {
   class ResolvedModelWrapper extends ReactComponent {
-    constructor(props, context) {
-      super(props, context);
-
-      this.model = context.model;
-      this.store = context.localStore;
-      this.deepKeys = deepKeys;
-      this.omitKeys = omitKeys;
-    }
-    shouldComponentUpdate(nextProps) {
-      return !shallowEqual(this.props, nextProps, {
-        deepKeys: this.deepKeys,
-        omitKeys: this.omitKeys,
+    shouldComponentUpdate(nextProps, nextState, nextContext) {
+      return !shallowEqual(this.context, nextContext) || !shallowEqual(this.props, nextProps, {
+        deepKeys,
+        omitKeys,
       });
     }
     render() {
+      const { model: parentModel, localStore } = this.context;
       const resolvedModel = resolveModel(
         this.props.model,
-        this.model);
+        parentModel);
 
       return (<WrappedComponent
         {...this.props}
         model={resolvedModel}
-        store={this.store || undefined}
+        store={localStore || undefined}
       />);
     }
   }

--- a/test/model-resolving-spec.js
+++ b/test/model-resolving-spec.js
@@ -195,4 +195,40 @@ describe('model resolving', () => {
       assert.equal(controlInput.value, 'control value');
     });
   });
+
+  it('deep resolves with dynamic model', () => {
+    const deepInitialState = {
+      foo: { value: 'fooValue' },
+      bar: { value: 'barValue' },
+    };
+
+    const deepStore = testCreateStore({
+      test: modelReducer('test', deepInitialState),
+      testForm: formReducer('test', deepInitialState),
+    });
+
+    class DynamicSubform extends React.Component {
+      state = { model: '.foo' };
+      render() {
+        return (
+          <Fieldset model={this.state.model}>
+            <button onClick={() => this.setState({ model: '.bar' })} />
+            <Control.text model=".value" />
+          </Fieldset>
+        );
+      }
+    }
+
+    const app = testRender(
+      <Form model="test">
+        <DynamicSubform />
+      </Form>, deepStore);
+
+    const input = TestUtils.findRenderedDOMComponentWithTag(app, 'input');
+    const button = TestUtils.findRenderedDOMComponentWithTag(app, 'button');
+
+    assert.equal(input.value, 'fooValue');
+    TestUtils.Simulate.click(button);
+    assert.equal(input.value, 'barValue');
+  });
 });


### PR DESCRIPTION
This fixed the case when the model dynamically changes in the middle of the chain - for example, you were using deep `Fieldset` hierarchy, and any of them had dynamic model
The problem is caused by the fact that resolveModel decorator, that is used internally to allow partial models, was caching model value upon mounting, thus preventing it from updating properly.
I've also removed several performance optimizations, as they were also preventing context updates. I'm open to any way this could be done better.