### PR TITLE
Avoid storeSubscription from being passed down as props to Field

### DIFF
--- a/src/components/field-component.js
+++ b/src/components/field-component.js
@@ -67,6 +67,7 @@ const fieldPropTypes = {
     dispatch: PropTypes.func,
     getState: PropTypes.func,
   }),
+  storeSubscription: PropTypes.any,
 };
 
 function getControlType(control, props, options) {


### PR DESCRIPTION
### The Problem
`storeSubscription` passed down to `<div>` created by Field component

### Related
https://github.com/davidkpiano/react-redux-form/issues/698