### PR TITLE
Improve React Native Form and Control implementations

### DIFF
--- a/docs/guides/react-native.md
+++ b/docs/guides/react-native.md
@@ -24,6 +24,7 @@ class App extends React.Component {
 export default App;
 ```
 
+<a name="native-controls"/>
 ## Native `<Control>`
 
 The following React Native iOS form controls are available:
@@ -110,12 +111,54 @@ export default Form;
 ```
 
 ## Using Custom Form Components
-If you want to use a third-party form control component, e.g., from Native Base, you need to use the base `react-redux-form/native` `Control` component directly. You also need to explicitly define the `mapProps`.
+If you are using a third-party form control component that delegates to a standard React Native iOS form control, you can use `Control.Custom` and provide a `delegate` prop. The `component` prop in this case is the custom component you're using.
+
+The supported controls are:
+
+* 'MapView'
+* 'Picker'
+* 'Switch'
+* 'TextInput'
+* 'DatePickerIOS'
+* 'SegmentedControlIOS'
+* 'Slider'
+
+Any custom form control can be used so long as it ultimately resolves to one of these React Native controls.
 
 ```jsx
 import React from 'react-native';
 import { Form, Control } from 'react-redux-form/native';
-import { Picker } from 'native-base';
+import { Input, Item } from 'native-base';
+
+class Form extends React.Component {
+  render() {
+    return (
+      <Form model="user"> 
+        <Item regular>
+          <Control.Custom
+            placeholder="Last Name"
+            model=".last_name"
+            component={Input}
+            delegate="TextInput"
+          />
+        </Item>
+      </Form>
+    );
+  }
+}
+
+export default Form;
+```
+
+## Using Non-Supported Custom Form Components
+If you are using a non-standard form control that does not implement one of the standard React Native iOS form controls ([listed here](#native-controls)), you will need to manually redefine `mapProps` for the control's event handlers.
+
+Below is an example of a custom `Picker` component with `mapProps` redefined.
+
+```jsx
+import React from 'react-native';
+import { Form, Control } from 'react-redux-form/native';
+import { Picker } from 'custom-form-library';
 
 class Form extends React.Component {
   render() {
@@ -148,12 +191,12 @@ class Form extends React.Component {
 export default Form;
 ```
 
-If you're using a custom `TextInput`, you will also need to define a special `getTextValue` method to stringify numeric inputs.
+Below is an example of a custom `Input` component. Note that an additional method is defined to handle coercing inputs to string format.
 
 ```jsx
 import React from 'react-native';
 import { Form, Control } from 'react-redux-form/native';
-import { Item, Input } from 'native-base';
+import { Input } from 'custom-form-library';
 
 function getTextValue(value) {
   if (typeof value === 'string' || typeof value === 'number') {
@@ -167,27 +210,25 @@ class Form extends React.Component {
   render() {
     return (
       <Form model="user">
-        <Item regular>
-          <Control
-            placeholder="First Name"
-            model=".first_name"
-            component={Input}
-            validators={{
-              required: val => val && val.length,
-            }}
-            mapProps={{
-              onResponderGrant: ({ onFocus }) => onFocus,
-              value: _props => ((! _props.defaultValue && 
-                ! _props.hasOwnProperty('value'))
-                ? getTextValue(_props.viewValue)
-                : _props.value),
-              onChangeText: ({ onChange }) => onChange,
-              onChange: undefined,   
-              onBlur: ({ onBlur, viewValue }) => () => onBlur(viewValue),
-              onFocus: ({ onFocus }) => onFocus,
-            }}
-          />
-        </Item>
+        <Control
+          placeholder="First Name"
+          model=".first_name"
+          component={Input}
+          validators={{
+            required: val => val && val.length,
+          }}
+          mapProps={{
+            onResponderGrant: ({ onFocus }) => onFocus,
+            value: _props => ((! _props.defaultValue && 
+              ! _props.hasOwnProperty('value'))
+              ? getTextValue(_props.viewValue)
+              : _props.value),
+            onChangeText: ({ onChange }) => onChange,
+            onChange: undefined,   
+            onBlur: ({ onBlur, viewValue }) => () => onBlur(viewValue),
+            onFocus: ({ onFocus }) => onFocus,
+          }}
+        />
       </Form>
     );
   }

--- a/docs/guides/react-native.md
+++ b/docs/guides/react-native.md
@@ -126,7 +126,6 @@ class Form extends React.Component {
           placeholder="Last Name"
           model=".last_name"
           component={Input}
-          delegate="TextInput"
         />
       </Form>
     );

--- a/docs/guides/react-native.md
+++ b/docs/guides/react-native.md
@@ -36,6 +36,8 @@ The following React Native iOS form controls are available:
 - `<Control.Switch>`
 - `<Control.TextInput>`
 
+See [below](#examples) for examples.
+
 The `model` prop is required for these controls to work with React Redux Form.
 
 For most controls, the original `onFocus` and `onBlur` props are mapped to:
@@ -81,3 +83,115 @@ By default, the `<Errors>` component will render:
 - and each error component as `<Text>`.
 
 Of course, you can override this by specifying the component in the `wrapper={...}` and `component={...}` props of `<Errors />`.
+
+<a name="examples"></a>
+## Control.Picker with Picker.Items
+Simply import `Picker` from `react-native`, and pass the `Picker.Item`s in as children.
+
+```jsx
+import React, { Picker } from 'react-native';
+import { Form, Control } from 'react-redux-form/native';
+
+class Form extends React.Component {
+  render() {
+    return (
+      <Form model="user">
+        <Control.Picker model=".gender">
+          <Picker.Item label="Male" value="male" />
+          <Picker.Item label="Female" value="female" />
+          <Picker.Item label="Other" value="other" />
+        </Control.Picker>
+      </Form>
+    );
+  }
+}
+
+export default Form;
+```
+
+## Using Custom Form Components
+If you want to use a third-party form control component, e.g., from Native Base, you need to use the base `react-redux-form/native` `Control` component directly. You also need to explicitly define the `mapProps`.
+
+```jsx
+import React from 'react-native';
+import { Form, Control } from 'react-redux-form/native';
+import { Picker } from 'native-base';
+
+class Form extends React.Component {
+  render() {
+    return (
+      <Form model="user">
+        <Control
+          component={Picker}
+          mapProps={{
+            onResponderGrant: ({ onFocus }) => onFocus,
+            onResponderRelease: ({ onBlur }) => onBlur,
+            selectedValue: ({ modelValue }) => modelValue,
+            onValueChange: ({ onChange }) => onChange,
+            onChange: undefined,
+          }}
+          model=".relationship"
+        >
+          <Picker.Item label="Select relationship" value="select" />
+          <Picker.Item label="Spouse" value="spouse" />
+          <Picker.Item label="Child" value="child" />
+          <Picker.Item label="Sibling" value="sibling" />
+          <Picker.Item label="Parent" value="parent" />
+          <Picker.Item label="Grandparent" value="grandparent" />
+          <Picker.Item label="Other" value="other" />
+        </Control>
+      </Form>
+    );
+  }
+}
+
+export default Form;
+```
+
+If you're using a custom `TextInput`, you will also need to define a special `getTextValue` method to stringify numeric inputs.
+
+```jsx
+import React from 'react-native';
+import { Form, Control } from 'react-redux-form/native';
+import { Item, Input } from 'native-base';
+
+function getTextValue(value) {
+  if (typeof value === 'string' || typeof value === 'number') {
+    return `${value}`;
+  }
+
+  return '';
+}
+
+class Form extends React.Component {
+  render() {
+    return (
+      <Form model="user">
+        <Item regular>
+          <Control
+            placeholder="First Name"
+            model=".first_name"
+            component={Input}
+            validators={{
+              required: val => val && val.length,
+            }}
+            mapProps={{
+              onResponderGrant: ({ onFocus }) => onFocus,
+              value: _props => ((! _props.defaultValue && 
+                ! _props.hasOwnProperty('value'))
+                ? getTextValue(_props.viewValue)
+                : _props.value),
+              onChangeText: ({ onChange }) => onChange,
+              onChange: undefined,   
+              onBlur: ({ onBlur, viewValue }) => () => onBlur(viewValue),
+              onFocus: ({ onFocus }) => onFocus,
+            }}
+          />
+        </Item>
+      </Form>
+    );
+  }
+}
+
+export default Form;
+```

--- a/docs/guides/react-native.md
+++ b/docs/guides/react-native.md
@@ -111,37 +111,23 @@ export default Form;
 ```
 
 ## Using Custom Form Components
-If you are using a third-party form control component that delegates to a standard React Native iOS form control, you can use `Control.Custom` and provide a `delegate` prop. The `component` prop in this case is the custom component you're using.
-
-The supported controls are:
-
-* 'MapView'
-* 'Picker'
-* 'Switch'
-* 'TextInput'
-* 'DatePickerIOS'
-* 'SegmentedControlIOS'
-* 'Slider'
-
-Any custom form control can be used so long as it ultimately resolves to one of these React Native controls.
+To use a third-party form control component select the appropriate `Control` type (e.g., `Control.TextInput`) and override the `component` prop with your custom component. The custom component must resolve to one of the supported React Native form control types. See the supported types [here](#native-controls). 
 
 ```jsx
 import React from 'react-native';
 import { Form, Control } from 'react-redux-form/native';
-import { Input, Item } from 'native-base';
+import { Input } from 'native-base';
 
 class Form extends React.Component {
   render() {
     return (
-      <Form model="user"> 
-        <Item regular>
-          <Control.Custom
-            placeholder="Last Name"
-            model=".last_name"
-            component={Input}
-            delegate="TextInput"
-          />
-        </Item>
+      <Form model="user">
+        <Control.TextInput
+          placeholder="Last Name"
+          model=".last_name"
+          component={Input}
+          delegate="TextInput"
+        />
       </Form>
     );
   }

--- a/src/native.js
+++ b/src/native.js
@@ -149,34 +149,6 @@ Control.Slider = (props) => (
   />
 );
 
-Control.Custom = (props) => {
-  const delegates = [
-    'MapView',
-    'Picker',
-    'Switch',
-    'TextInput',
-    'DatePickerIOS',
-    'SegmentedControlIOS',
-    'Slider',
-  ];
-
-  if (! props.delegate || ! delegates.includes(props.delegate)) {
-    throw new Error(`Delegate not found. Must be one of: [${delegates.map(d => `'${d}'`)}]`);
-  }
-  const CustomComponent = Control[props.delegate];
-
-  return (
-    <CustomComponent
-      component={props.component}
-      {...omit(props, 'mapProps')}
-    />
-  );
-};
-
-Control.Custom.propTypes = {
-  delegate: PropTypes.string.isRequired,
-};
-
 const NativeForm = (props) => <Form component={View} {...omit(props, 'mapProps')} />;
 const NativeFieldset = (props) => <Fieldset component={View} {...omit(props, 'mapProps')} />;
 const NativeErrors = (props) => (

--- a/src/native.js
+++ b/src/native.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import PropTypes from 'prop-types';
 import {
   MapView,
   Picker,

--- a/src/native.js
+++ b/src/native.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   MapView,
   Picker,
@@ -77,7 +78,7 @@ Control.Switch = (props) => (
     mapProps={{
       onResponderGrant: ({ onFocus }) => onFocus,
       onResponderRelease: ({ onBlur }) => onBlur,
-      value: ({ modelValue }) => !!modelValue,
+      value: ({ modelValue }) => ! ! modelValue,
       onValueChange: ({ onChange }) => onChange,
       onChange: noop,
       ...props.mapProps,
@@ -91,7 +92,7 @@ Control.TextInput = (props) => (
     component={TextInput}
     mapProps={{
       onResponderGrant: ({ onFocus }) => onFocus,
-      value: (_props) => ((!_props.defaultValue && !_props.hasOwnProperty('value'))
+      value: (_props) => ((! _props.defaultValue && ! _props.hasOwnProperty('value'))
         ? getTextValue(_props.viewValue)
         : _props.value),
       onChangeText: ({ onChange }) => onChange,
@@ -147,6 +148,34 @@ Control.Slider = (props) => (
     {...omit(props, 'mapProps')}
   />
 );
+
+Control.Custom = (props) => {
+  const delegates = [
+    'MapView',
+    'Picker',
+    'Switch',
+    'TextInput',
+    'DatePickerIOS',
+    'SegmentedControlIOS',
+    'Slider',
+  ];
+
+  if (! props.delegate || ! delegates.includes(props.delegate)) {
+    throw new Error(`Delegate not found. Must be one of: [${delegates.map(d => `'${d}'`)}]`);
+  }
+  const CustomComponent = Control[props.delegate];
+
+  return (
+    <CustomComponent
+      component={props.component}
+      {...omit(props, 'mapProps')}
+    />
+  );
+};
+
+Control.Custom.propTypes = {
+  delegate: PropTypes.string.isRequired,
+};
 
 const NativeForm = (props) => <Form component={View} {...omit(props, 'mapProps')} />;
 const NativeFieldset = (props) => <Fieldset component={View} {...omit(props, 'mapProps')} />;


### PR DESCRIPTION
This PR adds some examples for Inputs and Pickers for React Native. It also shows how to use Picker.Items in the standard native Control.Picker. I'm not certain my code examples are entirely correct, particularly as concerns the `getTextValue` function. Please review.