### PR TITLE
Change submission logic for regular form posts

### DIFF
--- a/src/components/form-component.js
+++ b/src/components/form-component.js
@@ -348,6 +348,9 @@ function createFormClass(s = defaultStrategy) {
       const formValid = formValue
         ? formValue.$form.valid
         : true;
+      
+      // prevent default form actions if the form is invalid.
+      if (e && this.props.action && !formValid) e.preventDefault();
 
       if (!validators && onSubmit && formValid) {
         onSubmit(modelValue, e);


### PR DESCRIPTION
If using `onSubmit`, it is only called when the form is valid. If using an `action` instead, the form can be submitted at any time regardless of the validity. This is not consistent.