### PR TITLE
Fix void type parameter in LocalForm definition

### DIFF
--- a/react-redux-form.d.ts
+++ b/react-redux-form.d.ts
@@ -404,7 +404,7 @@ interface LocalFormProps extends BaseFormProps {
      */
     model?: string;
 }
-export class LocalForm extends React.Component<LocalFormProps, void> { }
+export class LocalForm extends React.Component<LocalFormProps, {}> { }
 
 interface BaseFieldsetProps {
     /**


### PR DESCRIPTION
With recent react TS definition, components with void type parameters cannot be used in JSX, giving this error:

```
Error:(105, 17) TS2605:JSX element type 'LocalForm' is not a constructor function for JSX elements.
  Types of property 'state' are incompatible.
    Type 'void' is not assignable to type 'Readonly<{}>'.
```