### PR TITLE
typescript definition, add static Control.button property

### DIFF
--- a/react-redux-form.d.ts
+++ b/react-redux-form.d.ts
@@ -221,6 +221,7 @@ export class Control<T> extends React.Component<ControlProps<T>, {}> {
     static file: React.ComponentClass<ControlProps<HTMLInputElement>>;
     static select: React.ComponentClass<ControlProps<HTMLSelectElement>>;
     static reset: React.ComponentClass<ControlProps<HTMLButtonElement>>;
+    static button: React.ComponentClass<ControlProps<HTMLButtonElement>>;
 }
 
 export interface FieldProps<T> extends ControlProps<T> {


### PR DESCRIPTION
just add one line

react-redux-form.d.ts
`static button: React.ComponentClass<ControlProps<HTMLButtonElement>>;`

button is defined
https://github.com/davidkpiano/react-redux-form/blob/master/docs/api/Control.md

but definition doesn't have `Control.button`