### PR TITLE
Error Component has className props but definition isn't

### DIFF
--- a/react-redux-form.d.ts
+++ b/react-redux-form.d.ts
@@ -489,6 +489,10 @@ export interface ErrorsProps {
      * * component={CustomError} will wrap the error in a <CustomError> component, which will receive the same props as above.
      */
     component?: string | React.StatelessComponent<ErrorsProps & CustomComponentProps> | React.ComponentClass<ErrorsProps & CustomComponentProps>;
+  /**
+   * CSS Class Name(s)
+   */
+  className?: string;
 }
 
 export class Errors extends React.Component<ErrorsProps, {}> {


### PR DESCRIPTION
I add `className?: string` to ErrorProps only

it's currently supported but definition and [doc](https://github.com/davidkpiano/react-redux-form/blob/master/docs/api/Errors.md), both has missed

so

someone who can write english, need to update `Erros.md`

