### PR TITLE
Immutable support in actions.xor

### DIFF
--- a/src/actions/model-actions.js
+++ b/src/actions/model-actions.js
@@ -74,7 +74,7 @@ export function createModelActions(s = defaultStrategies) {
     const valueWithoutItem = value.filter((_item) => !iteratee(_item));
 
     return (s.length(value) === s.length(valueWithoutItem))
-      ? [...value, item]
+      ? s.push(value, item)
       : valueWithoutItem;
   }, s.array, 3);
 

--- a/test/actions-spec.js
+++ b/test/actions-spec.js
@@ -65,6 +65,22 @@ describe('model action creators', () => {
 
       fn(dispatch, getState);
     });
+
+    it('should change a collection by pushing an item to it via symmetric difference', done => {
+      const fn = actions.xor('foo.bar', 4);
+      const dispatch = action => {
+        done(assert.deepEqual(
+          action.value,
+          [1, 2, 3, 4]));
+      };
+      const getState = () => ({
+        foo: {
+          bar: [1, 2, 3],
+        },
+      });
+
+      fn(dispatch, getState);
+    });
   });
 
   describe('actions.push() thunk', () => {


### PR DESCRIPTION
The actions.xor function was using spread operator for an array concatenation when an item doesn't exist in the model value and it's a not correct behaviour when Immutable.js is used. I wrote a small fix and test case for the defaultStrategy version. Unfortunately I don't feel capable of writing actions test with Immutable.js support.