### PR TITLE
Resolve Issue 905, defaultChecked bug on Control.checkbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ examples/sandbox
 
 # Other
 .vscode/
+.idea/

--- a/src/actions/model-actions.js
+++ b/src/actions/model-actions.js
@@ -98,9 +98,8 @@ export function createModelActions(s = defaultStrategies) {
 
     if (typeof value === 'undefined') {
       return change(model, !currentValue);
-    } else {
-      return change(model, value);
     }
+    return change(model, value);
   };
 
   const check = (model, value) => (dispatch, getState) => {

--- a/src/actions/model-actions.js
+++ b/src/actions/model-actions.js
@@ -96,7 +96,11 @@ export function createModelActions(s = defaultStrategies) {
       return change(model, multiValue);
     }
 
-    return change(model, !currentValue);
+    if (typeof value === 'undefined') {
+      return change(model, !currentValue);
+    } else {
+      return change(model, value);
+    }
   };
 
   const check = (model, value) => (dispatch, getState) => {

--- a/src/components/control-component.js
+++ b/src/components/control-component.js
@@ -662,23 +662,24 @@ function createControlClass(s = defaultStrategy) {
     const modelString = getModel(model, state);
     const fieldValue = s.getFieldFromState(state, modelString)
       || initialFieldState;
+    const modelValue = s.get(state, modelString);
 
     return {
       model: modelString,
-      modelValue: s.get(state, modelString),
+      modelValue,
       fieldValue,
       controlProps: finalControlProps,
     };
   }
 
   const ConnectedControl = resolveModel(connect(mapStateToProps, null, null, {
-    areOwnPropsEqual(ownProps, nextOwnProps) {
-      return shallowEqual(ownProps, nextOwnProps, {
+    areOwnPropsEqual(nextOwnProps, ownProps) {
+      return shallowEqual(nextOwnProps, ownProps, {
         omitKeys: ['mapProps'],
       });
     },
-    areStatePropsEqual(stateProps, nextStateProps) {
-      return shallowEqual(stateProps, nextStateProps, {
+    areStatePropsEqual(nextStateProps, stateProps) {
+      return shallowEqual(nextStateProps, stateProps, {
         deepKeys: ['controlProps'],
       });
     },

--- a/src/constants/control-props-map.js
+++ b/src/constants/control-props-map.js
@@ -57,9 +57,7 @@ const controlPropsMap = {
   },
   checkbox: {
     ...standardPropsMap,
-    checked: (props) => (props.defaultChecked
-      ? props.checked
-      : isChecked(props)),
+    checked: isChecked,
   },
   radio: {
     ...standardPropsMap,

--- a/test/control-component-spec.js
+++ b/test/control-component-spec.js
@@ -303,9 +303,10 @@ Object.keys(testContexts).forEach((testKey) => {
         test: modelReducer('test', initialState),
       });
 
+      const reactCheckbox = <Control.checkbox model="test.single" />;
       const field = TestUtils.renderIntoDocument(
         <Provider store={store}>
-          <Control.checkbox model="test.single" />
+          {reactCheckbox}
         </Provider>
       );
 
@@ -325,12 +326,14 @@ Object.keys(testContexts).forEach((testKey) => {
         assert.equal(
           get(store.getState().test, 'single'),
           false, 'false');
+        assert.equal(checkbox.checked, false);
 
         TestUtils.Simulate.change(checkbox);
 
         assert.equal(
           get(store.getState().test, 'single'),
           true, 'true');
+        assert.equal(checkbox.checked, true);
       });
 
       it('should check/uncheck the checkbox when model is externally changed', () => {
@@ -345,6 +348,114 @@ Object.keys(testContexts).forEach((testKey) => {
 
       it('should uncheck the checkbox for any falsey value', () => {
         store.dispatch(actions.change('test.single', ''));
+
+        assert.equal(checkbox.checked, false);
+      });
+    });
+
+    describe('with <Control.checkbox /> (single toggle, dynamic form data, checked by default)', () => {
+      const initialState = getInitialState({ single: true });
+      const store = testCreateStore({
+        testForm: formReducer('test'),
+        test: modelReducer('test', initialState),
+      });
+
+      const field = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <Control.checkbox model="test.other" defaultChecked />
+        </Provider>
+      );
+
+      const checkbox = TestUtils.findRenderedDOMComponentWithTag(field, 'input');
+
+      it('should initially set the checkbox to checked if the model is truthy', () => {
+        assert.equal(checkbox.checked, true);
+      });
+
+      it('should give each radio input a name attribute of the model', () => {
+        assert.equal(checkbox.name, 'test.other');
+      });
+
+      it('should dispatch a change event when changed', () => {
+        TestUtils.Simulate.change(checkbox);
+
+        assert.equal(
+          get(store.getState().test, 'other'),
+          false, 'false');
+        assert.equal(checkbox.checked, false);
+
+        TestUtils.Simulate.change(checkbox);
+
+        assert.equal(
+          get(store.getState().test, 'other'),
+          true, 'true');
+        assert.equal(checkbox.checked, true);
+      });
+
+      it('should check/uncheck the checkbox when model is externally changed', () => {
+        store.dispatch(actions.change('test.other', true));
+        assert.equal(checkbox.checked, true);
+
+        store.dispatch(actions.change('test.other', false));
+        assert.equal(checkbox.checked, false);
+      });
+
+      it('should uncheck the checkbox for any falsey value', () => {
+        store.dispatch(actions.change('test.other', ''));
+
+        assert.equal(checkbox.checked, false);
+      });
+    });
+
+    describe('with <Control.checkbox /> (single toggle, dynamic form data, unchecked by default)', () => {
+      const initialState = getInitialState({ single: true });
+      const store = testCreateStore({
+        testForm: formReducer('test'),
+        test: modelReducer('test', initialState),
+      });
+
+      const field = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <Control.checkbox model="test.other" defaultChecked={false} />
+        </Provider>
+      );
+
+      const checkbox = TestUtils.findRenderedDOMComponentWithTag(field, 'input');
+
+      it('should initially set the checkbox to checked if the model is truthy', () => {
+        assert.equal(checkbox.checked, false);
+      });
+
+      it('should give each radio input a name attribute of the model', () => {
+        assert.equal(checkbox.name, 'test.other');
+      });
+
+      it('should dispatch a change event when changed', () => {
+        TestUtils.Simulate.change(checkbox);
+
+        assert.equal(
+          get(store.getState().test, 'other'),
+          true, 'true');
+
+        TestUtils.Simulate.change(checkbox);
+
+        assert.equal(
+          get(store.getState().test, 'other'),
+          false, 'false');
+      });
+
+      it('should check/uncheck the checkbox when model is externally changed', () => {
+        store.dispatch(actions.change('test.other', false));
+
+        assert.equal(checkbox.checked, false);
+
+        store.dispatch(actions.change('test.other', true));
+
+        assert.equal(checkbox.checked, true);
+      });
+
+      it('should uncheck the checkbox for any falsey value', () => {
+        store.dispatch(actions.change('test.other', ''));
 
         assert.equal(checkbox.checked, false);
       });

--- a/test/control-component-spec.js
+++ b/test/control-component-spec.js
@@ -303,10 +303,9 @@ Object.keys(testContexts).forEach((testKey) => {
         test: modelReducer('test', initialState),
       });
 
-      const reactCheckbox = <Control.checkbox model="test.single" />;
       const field = TestUtils.renderIntoDocument(
         <Provider store={store}>
-          {reactCheckbox}
+          <Control.checkbox model="test.single" />
         </Provider>
       );
 
@@ -368,7 +367,7 @@ Object.keys(testContexts).forEach((testKey) => {
 
       const checkbox = TestUtils.findRenderedDOMComponentWithTag(field, 'input');
 
-      it('should initially set the checkbox to checked if the model is truthy', () => {
+      it('should initially set the checkbox to checked when defaultChecked is true', () => {
         assert.equal(checkbox.checked, true);
       });
 
@@ -422,7 +421,7 @@ Object.keys(testContexts).forEach((testKey) => {
 
       const checkbox = TestUtils.findRenderedDOMComponentWithTag(field, 'input');
 
-      it('should initially set the checkbox to checked if the model is truthy', () => {
+      it('should initially set the checkbox to unchecked when defaultChecked is false', () => {
         assert.equal(checkbox.checked, false);
       });
 

--- a/test/control-component-spec.js
+++ b/test/control-component-spec.js
@@ -352,7 +352,7 @@ Object.keys(testContexts).forEach((testKey) => {
       });
     });
 
-    describe('with <Control.checkbox /> (single toggle, dynamic form data, checked by default)', () => {
+    describe('with <Control.checkbox /> (single toggle, dynamic form, defaultChecked)', () => {
       const initialState = getInitialState({ single: true });
       const store = testCreateStore({
         testForm: formReducer('test'),
@@ -406,7 +406,7 @@ Object.keys(testContexts).forEach((testKey) => {
       });
     });
 
-    describe('with <Control.checkbox /> (single toggle, dynamic form data, unchecked by default)', () => {
+    describe('with <Control.checkbox /> (single toggle, dynamic form, !defaultChecked)', () => {
       const initialState = getInitialState({ single: true });
       const store = testCreateStore({
         testForm: formReducer('test'),


### PR DESCRIPTION
This makes defaultChecked work as expected, populating the model properly and everything. Also added some failing tests for the bug, and then made the tests pass.

Minor largely irrelevant changes, I use IDEA as my IDE, and I needed to .gitignore its files.
Also, in debugging, I found that areOwnPropsEqual and areStatePropsEqual had a different signature than assumed, which was lightly confusing, so I fixed the signature. Finally, "modelValue" was set in the return function, which I edited to make it so that I could variable-inspect it, but then decided to leave it in the end, because it followed the format of all the other return values, and I felt dirty setting it back.

Actual meat and potatoes are in "src/actions/model-actions.js" and "src/constants/control-props-map.js", which, are, like, 5 lines of change. The change action was ignoring the second parameter, and control-props-map was giving weird results, and caring about defaultChecked. Not sure why, but removing it solved all things.