### PR TITLE
setPending should update subFields

### DIFF
--- a/src/reducers/form-actions-reducer.js
+++ b/src/reducers/form-actions-reducer.js
@@ -265,6 +265,13 @@ export function createFormActionsReducer(options) {
           retouched: false,
         };
 
+        subFieldUpdates = {
+          pending: action.pending,
+          submitted: false,
+          submitFailed: false,
+          retouched: false,
+        };
+
         parentFormUpdates = { pending: action.pending };
 
         break;

--- a/test/form-reducer-actions-spec.js
+++ b/test/form-reducer-actions-spec.js
@@ -255,11 +255,20 @@ describe('formReducer() (V1)', () => {
             ...initialFieldState,
             retouched: true,
           },
+          name: {
+            ...initialFieldState,
+          },
         },
         expectedForm: {
           pending: true,
         },
         expectedField: {
+          pending: true,
+          submitted: false,
+          submitFailed: false,
+          retouched: false,
+        },
+        expectedSubField: {
           pending: true,
           submitted: false,
           submitFailed: false,


### PR DESCRIPTION
It is often nice to disable form fields while submission is pending, this currently requires trying to find the form and manually pass that down to field components. 

However since `submitted` and `submitFailed` propagate to subfields it would be convenient if `pending` did also.