### PR TITLE
Preventing Object.keys from being called on a boolean

### DIFF
--- a/src/reducers/form-actions-reducer.js
+++ b/src/reducers/form-actions-reducer.js
@@ -368,9 +368,11 @@ export function createFormActionsReducer(options) {
           // If the form is invalid (due to async validity)
           // but its fields are valid and the value has changed,
           // the form should be "valid" again.
-          if ((!parentForm.$form.validity
-              || !parentForm.$form.validity
-              || !Object.keys(parentForm.$form.validity).length)
+          const validityIsBool = typeof parentForm.$form.validity === 'boolean';
+          const isInvalid = validityIsBool
+            ? !parentForm.$form.validity
+            : !Object.keys(parentForm.$form.validity).length;
+          if (isInvalid
             && !parentForm.$form.valid
             && isValid(parentForm, { async: false })) {
             return {


### PR DESCRIPTION
When validity is a boolean and true, then `Object.keys` will be called on a boolean which will cause errors in IE. This change is meant to be equivalent to the existing code, but makes sure that `Object.keys` is not called on `validity` when it is a boolean. 

This appears to fix this issue: https://github.com/davidkpiano/react-redux-form/issues/806
Adding the ES6 shim fixes this issue because it returns an empty array when a boolean is passed into `Object.keys`, but users should not be required to add this shim in order to avoid this issue.