### PR TITLE
Update Immutable docs

### DIFF
--- a/docs/guides/immutable.md
+++ b/docs/guides/immutable.md
@@ -13,9 +13,12 @@ import {
 // ... other imports
 
 class MyForm extends Component {
+  onFormSubmit(formObj) {
+    // ... access form fields e.g. formObj.get('name');
+  }
   render() {
     return (
-      <Form model="user">
+      <Form model="user" onSubmit={this.onFormSubmit}>
         <Control model=".name" />
         
         {/* ... other controls */}


### PR DESCRIPTION
For an hour or so I was wondering why my form validators and onSubmit function were returning undefined when accessing attributes e.g. `formObj.name`. Turns out, when using the immutable counterparts, things are returned as `Map`. 

Added `formObj.get('name');` so people will get a hint that it works that way.