### PR TITLE
Fix bug with validation on change where Object.keys called on undefined

### DIFF
--- a/src/reducers/form-actions-reducer.js
+++ b/src/reducers/form-actions-reducer.js
@@ -368,11 +368,9 @@ export function createFormActionsReducer(options) {
           // If the form is invalid (due to async validity)
           // but its fields are valid and the value has changed,
           // the form should be "valid" again.
-          const validityIsBool = typeof parentForm.$form.validity === 'boolean';
-          const isInvalid = validityIsBool
-            ? !parentForm.$form.validity
-            : !Object.keys(parentForm.$form.validity).length;
-          if (isInvalid
+          if ((!parentForm.$form.validity
+              || typeof parentForm.$form.validity === 'boolean'
+              || !Object.keys(parentForm.$form.validity).length)
             && !parentForm.$form.valid
             && isValid(parentForm, { async: false })) {
             return {


### PR DESCRIPTION
This change: https://github.com/davidkpiano/react-redux-form/commit/8a2d27b7df1bb3142ed540671ecaceeac2691451 makes it so Object.keys is not called on a boolean, but it now allows undefined through instead.

This PR should handle all three cases correctly (undefined, boolean, object)