### PR TITLE
Adding in formatter functionality

### DIFF
--- a/src/actions/model-actions.js
+++ b/src/actions/model-actions.js
@@ -136,7 +136,7 @@ export function createModelActions(s = defaultStrategies) {
     return inserted;
   }, s.array, 3);
 
-  const merge = createModifierAction(s.merge, {}, 2);
+  const merge = createModifierAction(s.merge, {}, 3);
 
   const omit = createModifierAction((value, props = []) => {
     const propsArray = typeof props === 'string'

--- a/src/components/control-component.js
+++ b/src/components/control-component.js
@@ -88,6 +88,7 @@ const propTypes = {
   component: PropTypes.any,
   dispatch: PropTypes.func,
   parser: PropTypes.func,
+  formatter: PropTypes.func,
   ignore: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.string,
@@ -149,7 +150,7 @@ function createControlClass(s = defaultStrategy) {
       this.willValidate = false;
 
       this.state = {
-        viewValue: props.modelValue,
+        viewValue: this.format(props.modelValue),
       };
     }
 
@@ -360,7 +361,12 @@ function createControlClass(s = defaultStrategy) {
 
     setViewValue(viewValue) {
       if (!this.props.isToggle) {
-        this.setState({ viewValue: this.parse(viewValue) });
+        if (this.props.formatter) {
+          const parsedValue = this.parse(viewValue);
+          this.setState({ viewValue: this.format(parsedValue) });
+        } else {
+          this.setState({ viewValue: this.parse(viewValue) });
+        }
       }
     }
 
@@ -430,6 +436,12 @@ function createControlClass(s = defaultStrategy) {
     parse(value) {
       return this.props.parser
         ? this.props.parser(value)
+        : value;
+    }
+
+    format(value) {
+      return this.props.formatter
+        ? this.props.formatter(value)
         : value;
     }
 

--- a/src/components/field-component.js
+++ b/src/components/field-component.js
@@ -29,6 +29,7 @@ const fieldPropTypes = {
     PropTypes.string,
   ]),
   parser: PropTypes.func,
+  formatter: PropTypes.func,
   updateOn: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.string,
@@ -242,6 +243,7 @@ function createFieldClass(customControlPropsMap = {}, s = defaultStrategy) {
     updateOn: 'change',
     asyncValidateOn: 'blur',
     parser: identity,
+    formatter: identity,
     changeAction: actions.change,
     dynamic: true,
     component: 'div',

--- a/test/field-formatter-spec.js
+++ b/test/field-formatter-spec.js
@@ -1,0 +1,67 @@
+import { assert } from 'chai';
+import React from 'react';
+import TestUtils from 'react-dom/test-utils';
+import { combineReducers, createStore } from 'redux';
+import { Provider } from 'react-redux';
+
+import { modelReducer, Field, formReducer } from '../src';
+
+describe('<Field formatter={...} />', () => {
+  it('should format the initial value immediately', () => {
+    const store = createStore(combineReducers({
+      test: modelReducer('test', { foo: 'initial' }),
+      testForm: formReducer('test', { foo: 'initial' }),
+    }));
+
+    const formatValue = val => val.toUpperCase();
+
+    const field = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <Field
+          model="test.foo"
+          formatter={formatValue}
+        >
+          <input type="text" />
+        </Field>
+      </Provider>
+    );
+
+    const input = TestUtils.findRenderedDOMComponentWithTag(field, 'input');
+
+    assert.equal(input.value, 'INITIAL');
+
+    assert.equal(store.getState().test.foo, 'initial');
+  });
+
+  it('should update the viewValue with only the data returned by formatter', () => {
+    const initial = { foo: '0123456789' };
+    const expected = '0123';
+    const inputValue = '012345678912341268374612837';
+
+    const store = createStore(combineReducers({
+      test: modelReducer('test', initial),
+      testForm: formReducer('test', initial),
+    }));
+
+    const formatValue = val => val.substring(0, 4);
+
+    const field = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <Field
+          model="test.foo"
+          formatter={formatValue}
+        >
+          <input type="text" />
+        </Field>
+      </Provider>
+    );
+
+    const input = TestUtils.findRenderedDOMComponentWithTag(field, 'input');
+    input.value = inputValue;
+    TestUtils.Simulate.change(input);
+
+    assert.equal(input.value, expected);
+
+    assert.equal(store.getState().test.foo, inputValue);
+  });
+});


### PR DESCRIPTION
This PR is meant to resolve #745.

*Design*

This functionality allows a function to be passed in as a formatter (in much the same way as parsers work).  This formatter should expect as an input the form's model value, and is expected to transform that value into the way it should look on the input field.

As an example:

```javascript
import React from 'react';
import PropTypes from 'prop-types';
import { Control, Errors } from 'react-redux-form';

const MonthYearInput = ({ name, ...rest }) => {
  // Converts a raw MMYY string into a more pretty "MM / YY" string
  const myFormatter = (val) => {
    const month = val.substring(0, 2);
    const year = val.substring(2, 4);
    return `${month} / ${year}`;
  };

  // Removes all of the non-numeric characters from "MM / YY", and limits the value to four chars
  const myParser = (val) => {
    const newVal = val.replace(/\D/g, '').substring(0, 4);
    return newVal;
  }

  return (
    <div className="input-wrapper">
      <Control.text
        model={name}
        parser={myParser}
        formatter={myFormatter}
      />
    </div>
  );
};

MonthYearInput.propTypes = {
  name: PropTypes.string.isRequired
};

MonthYearInput.defaultProps = {
};

export default MonthYearInput;
```

**Pros**

* This approach gives the full control to the developer, and uses a very simple implementation
* Easy to debug, as is it just a "hook" into the process of updating the `modelValue` from the `viewValue`

**Cons**

* Potentially unintuitive at times.  For example, if you wrote a `formatter` to append a dollar sign ($) to the front of a string, but didn't have a `parser` to strip it out of the model value, you would end up in a loop of continually appending dollar signs.  E.g. three changes would give you `$$$100`.

I'm using this locally now, and find it really helpful.  I'm open to any suggestions from @davidkpiano on how he would like this implemented though.  I've also added some test specs to verify code correctness.
