### PR TITLE
Fixed reset intent clearing bug

### DIFF
--- a/src/components/control-component.js
+++ b/src/components/control-component.js
@@ -403,15 +403,18 @@ function createControlClass(s = defaultStrategy) {
             return;
           }
           case 'validate':
-          case 'reset':
-            if (intent.type === 'reset') {
-              this.setViewValue(modelValue);
-              if (this.handleUpdate.cancel) {
-                this.handleUpdate.cancel();
-              }
-            }
             if (containsEvent(validateOn, 'change')) {
               this.validate({ clearIntents: intent });
+            }
+            return;
+          case 'reset':
+            this.setViewValue(modelValue);
+            if (this.handleUpdate.cancel) {
+              this.handleUpdate.cancel();
+            }
+            dispatch(actions.clearIntents(model, intent));
+            if (containsEvent(validateOn, 'change')) {
+              this.validate({});
             }
             return;
 

--- a/test/control-component-spec.js
+++ b/test/control-component-spec.js
@@ -1097,19 +1097,47 @@ Object.keys(testContexts).forEach((testKey) => {
         test: modelReducer('test', initialState),
       });
 
-      TestUtils.renderIntoDocument(
-        <Provider store={store}>
-          <Control.text
-            model="test.foo"
-          />
-        </Provider>
-      );
-
       it('should reset the control to the last loaded value', () => {
+        TestUtils.renderIntoDocument(
+          <Provider store={store}>
+            <Control.text
+              model="test.foo"
+            />
+          </Provider>
+        );
+
         store.dispatch(actions.load('test.foo', 'new foo'));
         store.dispatch(actions.reset('test.foo'));
 
         assert.equal(get(store.getState().test, 'foo'), 'new foo');
+      });
+
+      const onEvents = [
+        'change',
+        'focus',
+        'blur',
+      ];
+
+      onEvents.forEach((updateOn) => {
+        onEvents.forEach((validateOn) => {
+          const condition = `updateOn="${updateOn}", validateOn="${validateOn}"`;
+          it(`should clear reset intent when ${condition}`, () => {
+            TestUtils.renderIntoDocument(
+              <Provider store={store}>
+                <Control.text
+                  model="test.foo"
+                  updateOn={updateOn}
+                  validateOn={validateOn}
+                />
+              </Provider>
+            );
+
+            store.dispatch(actions.reset('test.foo'));
+            const hasResetIntent = store.getState().testForm.foo.intents
+              .some(intent => intent.type === 'reset');
+            assert.equal(hasResetIntent, false, 'has no pending reset intents');
+          });
+        });
       });
     });
 


### PR DESCRIPTION
It turns out, that when `validateOn !== 'change'` or when there is no validators, control component never cleared `reset` intent. This, in turn, means that when `updateOn !== 'change'` is set, control cannot be changed by user.
I've fixed this by always clearing the intent.
Fixes #982.

Feel free to suggest test improvements, I'm not sure this is currently done in optimal way. Should we check that text input is cleared instead (and is changeable by user after that)?