### PR TITLE
Allow nodes for the value of messages

### DIFF
--- a/src/components/errors-component.js
+++ b/src/components/errors-component.js
@@ -31,7 +31,7 @@ const propTypes = {
   // Provided props
   model: PropTypes.string.isRequired,
   messages: PropTypes.objectOf(PropTypes.oneOfType([
-    PropTypes.string,
+    PropTypes.node,
     PropTypes.func,
     PropTypes.bool,
   ])),


### PR DESCRIPTION
The `Errors` component would issue a proptype warning when passing an
element as the message, despite happily rendering it. Changing it to
from `string` to `node` will allow rendering renderable things without
throwing proptype warnings.

Fixes #989