### PR TITLE
Prevent changing values from array type to object

### DIFF
--- a/src/utils/get-form-value.js
+++ b/src/utils/get-form-value.js
@@ -1,4 +1,5 @@
 import mapValues from './map-values';
+import toArray from './to-array';
 
 export default function getFormValue(form) {
   if (form && !form.$form) {
@@ -15,7 +16,7 @@ export default function getFormValue(form) {
 
   delete result.$form;
 
-  const isArray = Array.isArray(form.$form.value);
+  const isArray = form && form.$form && Array.isArray(form.$form.value);
 
-  return isArray ? Object.values(result) : result;
+  return isArray ? toArray(result) : result;
 }

--- a/src/utils/get-form-value.js
+++ b/src/utils/get-form-value.js
@@ -15,5 +15,7 @@ export default function getFormValue(form) {
 
   delete result.$form;
 
-  return result;
+  const isArray = Array.isArray(form.$form.value);
+
+  return isArray ? Object.values(result) : result;
 }

--- a/src/utils/to-array.js
+++ b/src/utils/to-array.js
@@ -1,0 +1,9 @@
+export default function toArray(object) {
+  const result = [];
+  Object.keys(object).forEach(key => {
+    if (object.hasOwnProperty(key)) {
+      result.push(object[key]);
+    }
+  });
+  return result;
+}


### PR DESCRIPTION
I've got problem described in #726 while searching a possible solution for #729 I've noticed that change-action-reducer can remove specific keys if `removeKeys` specified in the change action. But it still works incorrectly if array field mutates to object. 