### PR TITLE
Fix setInitial form state shape malformation (#1006)

### DIFF
--- a/src/reducers/form-actions-reducer.js
+++ b/src/reducers/form-actions-reducer.js
@@ -37,19 +37,19 @@ const resetFieldState = (field, customInitialFieldState) => {
   );
 };
 
-const setInitialFieldState = (customInitialFieldState) => (field, key) => {
+const setInitialFieldState = (customInitialFieldState) => field => {
   if (!isPlainObject(field)) return field;
 
-  if (key === '$form') {
-    return updateFieldState(customInitialFieldState, {
-      value: field.value,
-      model: field.model,
-    });
-  }
-
   if (field.$form) {
-    return mapValues(field, (fieldState) =>
-      resetFieldState(fieldState, customInitialFieldState));
+    // eslint-disable-next-line arrow-body-style
+    return mapValues(field, (fieldState, key) => {
+      return key === '$form'
+        ? updateFieldState(customInitialFieldState, {
+          value: field.value,
+          model: field.model,
+        })
+        : resetFieldState(fieldState, customInitialFieldState);
+    });
   }
 
   return updateFieldState(customInitialFieldState, {

--- a/test/field-actions-spec.js
+++ b/test/field-actions-spec.js
@@ -1107,6 +1107,14 @@ Object.keys(testContexts).forEach((testKey) => {
             value: 'changed',
           });
       });
+
+      it('should maintain the expected state shape in sub forms', () => {
+        const reducer = formReducer('test', { somePrimitive: 1, someArray: [] });
+
+        const changedState = reducer(undefined, actions.setInitial('test'));
+
+        assert.isUndefined(changedState.someArray.$form.$form);
+      });
     });
 
     describe('resetValidity() and resetErrors()', () => {


### PR DESCRIPTION
## Bug

#1006 

## Why These Changes?

The investigation documented in #1006 makes clear that several functions are called in the whole process of "setting initial state". Of these, the only one I could find that only had one consumer was `setInitialFieldState`. It seems ideal that to choose to modify this function (if doing so can lead to a fix) so as to reduce the probability of regressions.

The function returned by `setInitialFieldState` used to accept two arguments, `val` and `key`. The `key` argument was (as far as I can tell) not being used in the (originally) intended way. Previously there was a code path for when `key === '$form'`. However, the only direct consumer of this function (`updateFields`, which can receive this function as `newState` or `newSubState`) would _never_ pass a string for `key`. Instead, it would pass an `Object` or `undefined` as the second argument. It seems that whatever the intended behaviour of the `key === '$form'` check was, there was a regression at some time in the past.

So, I removed that check entirely and instead moved the behaviour intended for that case (which is to use `updateFieldState`) in to the next `if` block, which only runs if the `field` is in fact a form (established when checking for the presence of `field.$form`).

A couple notes:

I added a test to make sure there isn't a regression on this in the future. With that said, the test only checks for the very specific type of malformation that had been happening (as opposed to doing a broader check, which I don't think I have enough context to put together (let alone the time)).

I disabled the eslint rule `arrow-body-style` on `form-reducer-actions.js:17` because as far as I can tell in this case it's at direct conflict with `no-confusing-arrow`. It seemed to me that the best readability result was to ignore `arrow-body-style` instead of ignoring `no-confusing-arrow`.

## Other

It looks like your `package-lock.json` `version` is out of date with your `package.json`. Not sure if that's intentional. `package.json` specifies the current version is `1.16.1`, `package-lock.json` specifies the current version as `1.15.0`.