### PR TITLE
Control component feature parity between Android and iOS

### DIFF
--- a/docs/guides/react-native.md
+++ b/docs/guides/react-native.md
@@ -29,13 +29,14 @@ export default App;
 
 The following React Native iOS form controls are available:
 
-- `<Control.DatePickerIOS>`
 - `<Control.MapView>`
 - `<Control.Picker>`
-- `<Control.SegmentedControlIOS>`
-- `<Control.Slider>` (note: `SliderIOS` is deprecated.)
 - `<Control.Switch>`
 - `<Control.TextInput>`
+- `<Control.Slider>` (note: `SliderIOS` is deprecated.)
+- `<Control.DatePickerIOS>`
+- `<Control.SegmentedControlIOS>`
+- [Control.DatePickerAndroid](#datePickerAndroid) (note: this is a function wrapper around `DatePickerAndroid`, and not a component.)
 
 See [below](#examples) for examples.
 
@@ -48,6 +49,32 @@ For most controls, the original `onFocus` and `onBlur` props are mapped to:
 The use of `updateOn="blur"` will work as expected for the controls, and is set by default on `<Control.MapView>` for performance reasons.
 
 **Important:** The use of `<Field>` in RRF Native is no longer necessary, and is deprecated. `<Control>` provides a much cleaner, succinct solution without superfluous React warnings about prop types.
+
+<a name="datePickerAndroid"></a>
+## Control.DatePickerAndroid
+A simple wrapper around [`DatePickerAndroid`](https://facebook.github.io/react-native/docs/datepickerandroid.html) added to give Android feature parity with iOS.
+
+Example usage:
+```
+export const MyDatePicker = Control.DatePickerAndroid({
+    date: new Date(),
+    mode: 'calendar',
+});
+```
+```
+try {
+    const { dismissed, year, month, day } = await MyDatePicker.open();
+    
+    if (!dismissed) {
+        const date = `${day}/${month}/${year}`
+        dispatch(setChosenDate({ date }));
+    }
+} catch (err) {
+    console.log('Uh oh, spaghetti-o...');
+}
+```
+
+[Full list of DatePickerAndroid arguments](https://facebook.github.io/react-native/docs/datepickerandroid.html#open)
 
 ## Native `<Form>`
 

--- a/docs/guides/react-native.md
+++ b/docs/guides/react-native.md
@@ -27,7 +27,7 @@ export default App;
 <a name="native-controls"/>
 ## Native `<Control>`
 
-The following React Native iOS form controls are available:
+The following React Native iOS and Android form controls are available:
 
 - `<Control.MapView>`
 - `<Control.Picker>`
@@ -36,6 +36,7 @@ The following React Native iOS form controls are available:
 - `<Control.Slider>` (note: `SliderIOS` is deprecated.)
 - `<Control.DatePickerIOS>`
 - `<Control.SegmentedControlIOS>`
+- `<Control.SegmentedControlAndroid>`
 - [Control.DatePickerAndroid](#datePickerAndroid) (note: this is a function wrapper around `DatePickerAndroid`, and not a component.)
 
 See [below](#examples) for examples.
@@ -75,6 +76,9 @@ try {
 ```
 
 [Full list of DatePickerAndroid arguments](https://facebook.github.io/react-native/docs/datepickerandroid.html#open)
+
+## Control.SegmentedControlAndroid
+This component wraps `react-native-segmented-control-tab`, full props reference [available here.](https://github.com/kirankalyan5/react-native-segmented-control-tab#props)
 
 ## Native `<Form>`
 

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "lodash.get": "~4.4.2",
     "lodash.topath": "~4.5.2",
     "prop-types": "^15.5.6",
+    "react-native-segmented-control-tab": "^3.2.1",
     "shallow-compare": "^1.2.1"
   },
   "peerDependencies": {

--- a/src/native.js
+++ b/src/native.js
@@ -4,7 +4,7 @@ import {
   MapView,
   Picker,
   DatePickerIOS,
-  DatePickerAndroid,
+  DatePickerAndroid as RNDatePickerAndroid,
   Switch,
   TextInput,
   SegmentedControlIOS,
@@ -40,6 +40,14 @@ function getTextValue(value) {
 
   return '';
 }
+
+const DatePickerAndroid = (...args) => ({
+  open: async () => {
+    const { action, year, month, day } = await RNDatePickerAndroid.open(...args);
+    const dismissed = action === RNDatePickerAndroid.dismissedAction;
+    return { dismissed, action, year, month, day };
+  },
+});
 
 const noop = () => undefined;
 
@@ -127,13 +135,7 @@ Control.DatePickerIOS = (props) => (
   />
 );
 
-Control.DatePickerAndroid = (...args) => ({
-  open: async () => {
-    const { action, year, month, day } = await DatePickerAndroid.open(...args);
-    const dismissed = action === DatePickerAndroid.dismissedAction;
-    return { dismissed, action, year, month, day };
-  },
-});
+Control.DatePickerAndroid = DatePickerAndroid;
 
 Control.SegmentedControlIOS = (props) => (
   <Control

--- a/src/native.js
+++ b/src/native.js
@@ -12,6 +12,7 @@ import {
   Text,
   View,
 } from 'react-native';
+import SegmentedControlAndroid from 'react-native-segmented-control-tab';
 
 
 import modelReducer from './reducers/model-reducer';
@@ -140,6 +141,20 @@ Control.DatePickerAndroid = DatePickerAndroid;
 Control.SegmentedControlIOS = (props) => (
   <Control
     component={SegmentedControlIOS}
+    mapProps={{
+      onResponderGrant: ({ onFocus }) => onFocus,
+      selectedIndex: ({ values, modelValue }) => values.indexOf(modelValue),
+      onValueChange: ({ onChange }) => onChange,
+      onChange: noop,
+      ...props.mapProps,
+    }}
+    {...omit(props, 'mapProps')}
+  />
+);
+
+Control.SegmentedControlAndroid = (props) => (
+  <Control
+    component={SegmentedControlAndroid}
     mapProps={{
       onResponderGrant: ({ onFocus }) => onFocus,
       selectedIndex: ({ values, modelValue }) => values.indexOf(modelValue),

--- a/src/native.js
+++ b/src/native.js
@@ -4,6 +4,7 @@ import {
   MapView,
   Picker,
   DatePickerIOS,
+  DatePickerAndroid,
   Switch,
   TextInput,
   SegmentedControlIOS,
@@ -125,6 +126,14 @@ Control.DatePickerIOS = (props) => (
     {...omit(props, 'mapProps')}
   />
 );
+
+Control.DatePickerAndroid = (...args) => ({
+  open: async () => {
+    const { action, year, month, day } = await DatePickerAndroid.open(...args);
+    const dismissed = action === DatePickerAndroid.dismissedAction;
+    return { dismissed, action, year, month, day };
+  },
+});
 
 Control.SegmentedControlIOS = (props) => (
   <Control

--- a/yarn.lock
+++ b/yarn.lock
@@ -3508,6 +3508,12 @@ react-dom@^15.6.1:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
+react-native-segmented-control-tab@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/react-native-segmented-control-tab/-/react-native-segmented-control-tab-3.2.1.tgz#29dc3700c3d954e5bdb5dd5cc48f4c4143a9375e"
+  dependencies:
+    prop-types "^15.5.10"
+
 react-redux@~5.0.0:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.6.tgz#23ed3a4f986359d68b5212eaaa681e60d6574946"


### PR DESCRIPTION
Added in Control properties that were available on iOS but not Android: Control.DatePickerAndroid (ReactNative.DatePickerAndroid) and Control.SegmentedControlAndroid (`react-native-segmented-control-tab`)

Added these pretty quickly and I've not run the code, but all tests are passing.

Control.DatePickerAndroid isn't a component, might be better to make it a component to keep Control consistent.

Control.SegmentedControlAndroid uses the third-party package `react-native-segmented-control-tab`. @davidkpiano you may want to check out the package to see it's up to your standards :-).

I haven't used this package (yet), so apologies if I've missed something fundamental. Also sorry I wasn't able to test the new features; I'm at work at the moment and likely to be busy this evening. If someone is broken I can fix in a couple of days.