### PR TITLE
Flush updates before blur if Control is debounceable

### DIFF
--- a/src/components/control-component-factory.js
+++ b/src/components/control-component-factory.js
@@ -137,6 +137,11 @@ function createControlClass(s) {
 
       if (props.debounce) {
         this.handleUpdate = debounce(this.handleUpdate, props.debounce);
+        const oldHandleBlur = this.handleBlur;
+        this.handleBlur = (...args) => {
+          this.handleUpdate.flush();
+          oldHandleBlur.call(this, args);
+        };
       }
 
       this.willValidate = false;


### PR DESCRIPTION
Blurring before updates are finished causes the field to have a touched state but not have the latest value.
If a error handler only shows error if a field has been touched, the error message will be visible for the duration of the debounce before disappearing.