### PR TITLE
Update typings for error messages prop

### DIFF
--- a/react-redux-form.d.ts
+++ b/react-redux-form.d.ts
@@ -39,10 +39,10 @@ interface ErrorsObject {
     [key: string]: boolean | string;
 }
 interface ErrorsMessageSelector {
-    (val: any): string;
+    (val: any): string | JSX.Element;
 }
 interface ErrorsComponentMessages {
-    [key: string]: string | ErrorsMessageSelector;
+    [key: string]: string | ErrorsMessageSelector | JSX.Element | bool;
 }
 
 interface FormValidators {


### PR DESCRIPTION
Allow to return JSX from messages object

If I understood correctly, there is no restriction on messages object value, so you can return string or any other JSX elements:
https://github.com/davidkpiano/react-redux-form/blob/master/src/components/errors-component.js#L33