### PR TITLE
Fix uncontrolled input warning

### DIFF
--- a/src/components/control-component-factory.js
+++ b/src/components/control-component-factory.js
@@ -664,6 +664,10 @@ function createControlClass(s) {
           controlProps.children
         );
       }
+      // Set a default value to prevent it being treated as uncontrolled input
+      if (!controlProps.value && !mappedProps.value) {
+        mappedProps.value = '';
+      }
       return createElement(
         ComponentWrapper,
         {

--- a/src/components/control-strip-defaults-component.js
+++ b/src/components/control-strip-defaults-component.js
@@ -17,6 +17,9 @@ class ComponentWrapper extends Component {
     if (getRef) {
       otherProps.ref = getRef;
     }
+    if (!otherProps.value) {
+      otherProps.value = '';
+    }
     const WrappedComponent = component;
     return <WrappedComponent {...otherProps} />;
   }

--- a/src/components/control-strip-defaults-component.js
+++ b/src/components/control-strip-defaults-component.js
@@ -17,9 +17,6 @@ class ComponentWrapper extends Component {
     if (getRef) {
       otherProps.ref = getRef;
     }
-    if (!otherProps.value) {
-      otherProps.value = '';
-    }
     const WrappedComponent = component;
     return <WrappedComponent {...otherProps} />;
   }


### PR DESCRIPTION
Thank you for this library!   I've been getting an uncontrolled input warning on changing input fields and found a fix by providing a fallback to empty string when value is undefined.

Possibly a duplicate of #739, #714, and #630.