### PR TITLE
Revert defaulting control value to a string

### DIFF
--- a/src/components/control-component-factory.js
+++ b/src/components/control-component-factory.js
@@ -664,10 +664,6 @@ function createControlClass(s) {
           controlProps.children
         );
       }
-      // Set a default value to prevent it being treated as uncontrolled input
-      if (!controlProps.value && !mappedProps.value) {
-        mappedProps.value = '';
-      }
       return createElement(
         ComponentWrapper,
         {


### PR DESCRIPTION
This reverts the change in #1151. Control should not determine what type the value should be. Control needs to return the value as is.

See discussion here: https://github.com/davidkpiano/react-redux-form/commit/ca5dda45ea3599aacb0db60a7e2a6cedf71f1079#r29259155 