### PR TITLE
FIX - createForms was not exported for react-native

### DIFF
--- a/src/native.js
+++ b/src/native.js
@@ -19,7 +19,7 @@ import modelReducer from './reducers/model-reducer';
 import formReducer from './reducers/form-reducer';
 import modeled from './enhancers/modeled-enhancer';
 import actions from './actions';
-import combineForms from './reducers/forms-reducer';
+import { createForms }, combineForms from './reducers/forms-reducer';
 import initialFieldState from './constants/initial-field-state';
 import actionTypes from './action-types';
 import Form from './components/form-component';
@@ -195,6 +195,7 @@ export {
   // Reducers
   formReducer,
   modelReducer,
+  createForms,
   combineForms,
 
   // Constants


### PR DESCRIPTION
So instead of doing `import { createForms } from 'react-redux-form/native'` I had to import it from `'react-redux-form/lib/reducers/forms-reducer'` which is not optimal