### PR TITLE
924 form cache clearing

### DIFF
--- a/src/components/form-component.js
+++ b/src/components/form-component.js
@@ -10,7 +10,7 @@ import getValidity from '../utils/get-validity';
 import invertValidators from '../utils/invert-validators';
 import isValidityInvalid from '../utils/is-validity-invalid';
 import isValid from '../form/is-valid';
-import getForm from '../utils/get-form';
+import getForm, { clearGetFormCacheForModel } from '../utils/get-form';
 import getModel from '../utils/get-model';
 import getField from '../utils/get-field';
 import deepCompareChildren from '../utils/deep-compare-children';
@@ -409,6 +409,7 @@ function createFormClass(s = defaultStrategy) {
 
   function mapStateToProps(state, { model }) {
     const modelString = getModel(model, state);
+    clearGetFormCacheForModel(modelString);
     const form = s.getForm(state, modelString);
 
     invariant(form,

--- a/src/utils/get-form.js
+++ b/src/utils/get-form.js
@@ -76,7 +76,16 @@ let formStateKeyCache = {};
 export const clearGetFormCache =
   () => formStateKeyCache = {}; // eslint-disable-line no-return-assign
 
+export const clearGetFormCacheForModel =
+  (modelString) => delete formStateKeyCache[modelString]; // eslint-disable-line no-return-assign
+
 const getFormStateKeyCached = (() => (state, modelString, s = defaultStrategy) => {
+  // console.log('formStateKeyCache');
+  // console.log(formStateKeyCache);
+  // console.log('result');
+  // const result = getFormStateKey(state, modelString, s);
+  // console.log(result);
+
   if (formStateKeyCache[modelString]) return formStateKeyCache[modelString];
 
   const result = getFormStateKey(state, modelString, s);

--- a/src/utils/get-form.js
+++ b/src/utils/get-form.js
@@ -80,12 +80,6 @@ export const clearGetFormCacheForModel =
   (modelString) => delete formStateKeyCache[modelString]; // eslint-disable-line no-return-assign
 
 const getFormStateKeyCached = (() => (state, modelString, s = defaultStrategy) => {
-  // console.log('formStateKeyCache');
-  // console.log(formStateKeyCache);
-  // console.log('result');
-  // const result = getFormStateKey(state, modelString, s);
-  // console.log(result);
-
   if (formStateKeyCache[modelString]) return formStateKeyCache[modelString];
 
   const result = getFormStateKey(state, modelString, s);

--- a/src/utils/get-form.js
+++ b/src/utils/get-form.js
@@ -77,7 +77,8 @@ export const clearGetFormCache =
   () => formStateKeyCache = {}; // eslint-disable-line no-return-assign
 
 export const clearGetFormCacheForModel =
-  (modelString) => delete formStateKeyCache[modelString]; // eslint-disable-line no-return-assign
+  // eslint-disable-next-line
+  (modelString) => delete formStateKeyCache[modelString];
 
 const getFormStateKeyCached = (() => (state, modelString, s = defaultStrategy) => {
   if (formStateKeyCache[modelString]) return formStateKeyCache[modelString];

--- a/test/form-component-spec.js
+++ b/test/form-component-spec.js
@@ -2044,7 +2044,7 @@ Object.keys(testContexts).forEach((testKey) => {
 
 
     describe('form validation with models in collections', () => {
-      it('should call onSubmitFailed() prop if if collection item present at initialization', () => {
+      it('validates if item in initialState', () => {
         const initialState = getInitialState({ test1: {} });
 
         const store = testCreateStore({
@@ -2092,7 +2092,7 @@ Object.keys(testContexts).forEach((testKey) => {
         assert.isTrue(store.getState().testForm.test1.$form.submitFailed);
       });
 
-      it('should call onSubmitFailed() prop if if collection item not present at initialization', () => {
+      it('validates if item not in initialState', () => {
         const initialState = getInitialState({ test1: {} });
 
         const store = testCreateStore({

--- a/test/form-component-spec.js
+++ b/test/form-component-spec.js
@@ -2042,6 +2042,106 @@ Object.keys(testContexts).forEach((testKey) => {
       });
     });
 
+
+    describe('form validation with models in collections', () => {
+      it('should call onSubmitFailed() prop if if collection item present at initialization', () => {
+        const initialState = getInitialState({ test1: {} });
+
+        const store = testCreateStore({
+          test: modelReducer('tests', initialState),
+          testForm: formReducer('tests', initialState),
+        });
+
+        let handleSubmitFailedCalledWith = null;
+
+        function handleSubmitFailed(val) {
+          handleSubmitFailedCalledWith = val;
+        }
+
+        const form = TestUtils.renderIntoDocument(
+          <Provider store={store}>
+            <Form
+              model="tests.test1"
+              onSubmitFailed={handleSubmitFailed}
+              validators={{
+                foo: (val) => val,
+              }}
+            >
+              <Control model=".foo" />
+            </Form>
+          </Provider>
+        );
+
+        const formNode = TestUtils.findRenderedDOMComponentWithTag(form, 'form');
+
+        TestUtils.Simulate.submit(formNode);
+
+        assert.containSubset(handleSubmitFailedCalledWith, {
+          $form: {
+            model: 'tests.test1',
+            valid: false,
+          },
+          foo: {
+            model: 'tests.test1.foo',
+            valid: false,
+            errors: true,
+          },
+        });
+
+        assert.isFalse(store.getState().testForm.test1.$form.pending);
+        assert.isTrue(store.getState().testForm.test1.$form.submitFailed);
+      });
+
+      it('should call onSubmitFailed() prop if if collection item not present at initialization', () => {
+        const initialState = getInitialState({ test1: {} });
+
+        const store = testCreateStore({
+          test: modelReducer('tests', initialState),
+          testForm: formReducer('tests', initialState),
+        });
+
+        let handleSubmitFailedCalledWith = null;
+
+        function handleSubmitFailed(val) {
+          handleSubmitFailedCalledWith = val;
+        }
+
+        const form = TestUtils.renderIntoDocument(
+          <Provider store={store}>
+            <Form
+              model="tests.test2"
+              onSubmitFailed={handleSubmitFailed}
+              validators={{
+                foo: (val) => val,
+              }}
+            >
+              <Control model=".foo" />
+            </Form>
+          </Provider>
+        );
+
+        const formNode = TestUtils.findRenderedDOMComponentWithTag(form, 'form');
+
+        TestUtils.Simulate.submit(formNode);
+
+        assert.containSubset(handleSubmitFailedCalledWith, {
+          $form: {
+            model: 'tests.test2',
+            valid: false,
+          },
+          foo: {
+            model: 'tests.test2.foo',
+            valid: false,
+            errors: true,
+          },
+        });
+
+        assert.isFalse(store.getState().testForm.test2.$form.pending);
+        assert.isTrue(store.getState().testForm.test2.$form.submitFailed);
+      });
+    });
+
+
     describe('getDispatch() prop', () => {
       it('should provide dispatch to callback', (done) => {
         const initialState = getInitialState({ foo: '' });


### PR DESCRIPTION
Fixes the issue described here - https://github.com/davidkpiano/react-redux-form/issues/924

Without understanding the internals in too much depth, it looks like `formStateKeyCache` was introduced as a way to track which parent form relationships for the models provided on `Field` attributes, in a way that would allow both `Fields` and `Forms` to use that `get-form` utility class.

Where this seems to break down is that for form-level models that aren't present at initialization, they never get the proper form structure in redux.

This PR addresses that by resetting the cached data form the provided model string, but only within the form component, and only when the state is being mapped to that model initially.