### PR TITLE
FIX - in react@16.5 ReactNative View is an Object

### DIFF
--- a/src/components/errors-component.js
+++ b/src/components/errors-component.js
@@ -40,6 +40,7 @@ const propTypes = {
     PropTypes.string,
     PropTypes.func,
     PropTypes.element,
+    PropTypes.object,
   ]),
   component: PropTypes.oneOfType([
     PropTypes.string,


### PR DESCRIPTION
When updating to react-native@0.57, I get an error because of bad proptype for wrapper.
In ReactNative, the Error component gets a View wrapper by default.
When View get a `function` type in react-native@0.50 it gets an `object` type in react-native@0.57 which give me an error.

I'm not sure it's the only component which will have the problem.