### PR TITLE
Fix async validators capturing and overwriting validation results

### DIFF
--- a/src/components/control-component-factory.js
+++ b/src/components/control-component-factory.js
@@ -329,7 +329,9 @@ function createControlClass(s) {
 
       mapValues(asyncValidators, (validator, key) => {
         const outerDone = (valid) => {
-          const validity = i.merge(fieldValue.validity, { [key]: valid });
+          // get current fieldValue as another validator may have already been processed.
+          const currentFieldValue = this.props.fieldValue;
+          const validity = i.merge(currentFieldValue.validity, { [key]: valid });
 
           dispatch(actions.setValidity(model, validity));
         };


### PR DESCRIPTION
I noticed that when there are two or more asyncValidators, the last one calling `done()` overwrote the results of all validators that finished before.

The reason was that `fieldValue` was captured when the validators were kicked off, and then merged at `done()` (`outerDone()` in the code), even if they had changed.

This also resolves #1013.