### PR TITLE
added array as allowed propType for control/field

### DIFF
--- a/src/components/control-component-factory.js
+++ b/src/components/control-component-factory.js
@@ -42,6 +42,7 @@ const propTypes = {
   model: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.string,
+    PropTypes.array,
   ]).isRequired,
   modelValue: PropTypes.any,
   viewValue: PropTypes.any,

--- a/src/components/field-component.js
+++ b/src/components/field-component.js
@@ -23,6 +23,7 @@ const fieldPropTypes = {
   model: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.string,
+    PropTypes.array,
   ]).isRequired,
   component: PropTypes.oneOfType([
     PropTypes.func,


### PR DESCRIPTION
@davidkpiano 
as explained on #986 arrays can be used to specify a model on fields, this adds array proptype to field and control to prevent a warning.