### PR TITLE
Fix deprecated react lifecycle methods

### DIFF
--- a/src/components/control-component-factory.js
+++ b/src/components/control-component-factory.js
@@ -157,7 +157,7 @@ function createControlClass(s) {
       this.handleLoad();
     }
 
-    componentWillReceiveProps({ modelValue }) {
+    UNSAFE_componentWillReceiveProps({ modelValue }) {
       if (modelValue !== this.props.modelValue) {
         this.setViewValue(modelValue);
       }

--- a/src/components/form-component.js
+++ b/src/components/form-component.js
@@ -100,7 +100,7 @@ function createFormClass(s = defaultStrategy) {
       }
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
       if (containsEvent(nextProps.validateOn, 'change')) {
         this.validate(nextProps);
       }


### PR DESCRIPTION
This runs `npx react-codemod rename-unsafe-lifecycles` to replace unsafe methods